### PR TITLE
docs: 合并所有 Markdown 为单一文档并附带优化建议

### DIFF
--- a/ALL_DOCS_MERGED.md
+++ b/ALL_DOCS_MERGED.md
@@ -1,0 +1,2788 @@
+# 项目 Markdown 文档合并版
+
+> 自动汇总仓库内全部 `.md` 文档，并附带可优化项检查结论。
+
+## 目录
+
+- [ADMIN_QUICKSTART.md](#file-1-admin_quickstartmd)
+- [ADMIN_README.md](#file-2-admin_readmemd)
+- [AUTH_GUIDE.md](#file-3-auth_guidemd)
+- [CHANGELOG.md](#file-4-changelogmd)
+- [DEBIAN12_DEPLOY.md](#file-5-debian12_deploymd)
+- [DEPLOYMENT_CHECKLIST.md](#file-6-deployment_checklistmd)
+- [GET_CHANNEL_ID.md](#file-7-get_channel_idmd)
+- [IMPLEMENTATION_SUMMARY.md](#file-8-implementation_summarymd)
+- [JWT_FIXES.md](#file-9-jwt_fixesmd)
+- [MIGRATE_GUIDE.md](#file-10-migrate_guidemd)
+- [P2_BADGE_FIX_SUMMARY.md](#file-11-p2_badge_fix_summarymd)
+- [QUICKSTART.md](#file-12-quickstartmd)
+- [README.md](#file-13-readmemd)
+- [REVERSE_PROXY.md](#file-14-reverse_proxymd)
+- [UPGRADE_README.md](#file-15-upgrade_readmemd)
+- [admin/README.md](#file-16-admin-readmemd)
+- [bot/README.md](#file-17-bot-readmemd)
+- [bot2/README.md](#file-18-bot2-readmemd)
+
+## 可优化项检查
+
+### 1. 可继续精简的占位文档
+以下文档仅保留“文档已合并”说明，可在 README 维护稳定锚点后改为相对链接跳转，减少重复维护：
+- `ADMIN_QUICKSTART.md`
+- `ADMIN_README.md`
+- `DEBIAN12_DEPLOY.md`
+- `GET_CHANNEL_ID.md`
+- `REVERSE_PROXY.md`
+
+### 2. 主题重复可统一
+- 认证升级主题分散在 `AUTH_GUIDE.md`、`UPGRADE_README.md`、`DEPLOYMENT_CHECKLIST.md`、`IMPLEMENTATION_SUMMARY.md`、`JWT_FIXES.md`、`P2_BADGE_FIX_SUMMARY.md`，可保留“1份主文档 + 其余索引文档”模式。
+- 对“快速开始”内容可统一单一入口（`README.md` + `QUICKSTART.md`）并在其他文档改为引用。
+
+### 3. 结构优化建议
+- 建议新增 `docs/` 目录按主题分层（deploy/auth/migrate/bot/changelog）。
+- 建议在 `README.md` 增加“文档导航矩阵”（新用户/运维/开发/升级）。
+- 对历史修复总结（如 `P2_BADGE_FIX_SUMMARY.md`）可转入 changelog 的历史章节，减少碎片化。
+
+---
+
+## <a id="file-1-admin_quickstartmd"></a>ADMIN_QUICKSTART.md
+
+# 文档已合并
+
+本文件内容已合并至项目主说明文档 `README.md`，请改为阅读：
+
+- `README.md` -> `统一说明（已合并）`
+- `README.md` -> `更新日志（主说明文件）`
+- `README.md` -> `保留数据迁移流程`
+
+---
+
+## <a id="file-2-admin_readmemd"></a>ADMIN_README.md
+
+# 文档已合并
+
+本文件内容已合并至项目主说明文档 `README.md`，请改为阅读：
+
+- `README.md` -> `统一说明（已合并）`
+- `README.md` -> `更新日志（主说明文件）`
+- `README.md` -> `保留数据迁移流程`
+
+---
+
+## <a id="file-3-auth_guidemd"></a>AUTH_GUIDE.md
+
+# 管理后台认证配置指南
+
+## 📋 概述
+
+管理后台已升级为基于 **API Key + JWT Token** 的双重认证机制，提供更安全、现代化的身份验证。
+
+## 🔐 认证原理
+
+1. **API Key**: 长期有效的密钥，存储在服务器配置中
+2. **JWT Token**: 临时访问令牌，有效期 2 小时，由 API Key 换取
+3. **认证流程**: 
+   - 管理员输入 API Key 登录
+   - 服务器验证 API Key 有效性
+   - 返回 JWT Token 给客户端
+   - 客户端在后续请求中携带 Token
+   - 服务器验证 Token 有效性
+
+## ⚙️ 配置步骤
+
+### 1. 生成 API Key
+
+#### Linux/Mac:
+```bash
+chmod +x generate-api-key.sh
+./generate-api-key.sh
+```
+
+#### Windows PowerShell:
+```powershell
+.\generate-api-key.ps1
+```
+
+或者手动生成（推荐）:
+```bash
+openssl rand -hex 32
+```
+
+### 2. 配置 data.json
+
+编辑 `data.json` 文件，添加生成的 API Key:
+
+```json
+{
+  "telegram": {
+    "bot_token": "YOUR_BOT_TOKEN",
+    "channel_id": "-1001234567890"
+  },
+  "mysql": {
+    "host": "localhost",
+    "port": 3306,
+    "username": "tg_imagebed",
+    "password": "your_password",
+    "database": "tg_imagebed"
+  },
+  "admin": {
+    "user_ids": [123456789, 987654321]
+  },
+  "api_keys": [
+    "your-secret-api-key-here-change-this-in-production"
+  ]
+}
+```
+
+### 3. 重启服务
+
+```bash
+# 如果使用 systemd
+sudo systemctl restart telegram-bot-api
+
+# 或者手动重启
+./stop.sh
+./start.sh
+```
+
+### 4. 访问管理后台
+
+1. 打开浏览器访问：`http://your-domain:8080/admin.html`
+2. 输入配置的 API Key
+3. 点击登录
+
+## 🛡️ 安全最佳实践
+
+### API Key 管理
+
+✅ **推荐做法**:
+- 使用至少 32 字节的随机字符串（64 个十六进制字符）
+- 定期更换 API Key（建议每 3-6 个月）
+- 为不同管理员配置不同的 API Key
+- 使用环境变量或密钥管理服务存储 API Key
+- 在生产环境中使用 HTTPS
+
+❌ **避免做法**:
+- 不要使用默认或示例中的 API Key
+- 不要将 API Key 提交到版本控制系统
+- 不要在日志或错误信息中暴露完整 API Key
+- 不要在前端代码中硬编码 API Key
+
+### 多管理员配置
+
+支持配置多个 API Key，每个管理员一个：
+
+```json
+{
+  "api_keys": [
+    "admin1-secret-key-here",
+    "admin2-secret-key-here",
+    "admin3-secret-key-here"
+  ]
+}
+```
+
+### Token 特性
+
+- **有效期**: 2 小时
+- **自动过期**: Token 过期后需要重新登录
+- **安全存储**: Token 存储在浏览器 localStorage 中
+- **自动续期**: 每次请求会自动验证 Token 有效性
+
+## 🔧 故障排查
+
+### 问题 1: 无法登录，提示 "API Key 无效"
+
+**解决方案**:
+1. 检查 data.json 中是否配置了 api_keys
+2. 确认 API Key 格式正确（无多余空格）
+3. 重启服务使配置生效
+4. 查看服务器日志确认配置加载成功
+
+### 问题 2: 登录后立即被退出
+
+**解决方案**:
+1. 检查浏览器控制台是否有 401 错误
+2. 确认服务器时间准确（JWT 依赖时间验证）
+3. 清除浏览器缓存和 localStorage 后重试
+
+### 问题 3: 提示 "未配置 API Keys"
+
+**解决方案**:
+1. 在 data.json 中添加 api_keys 配置
+2. 确保 JSON 格式正确（注意逗号分隔）
+3. 重启服务
+
+## 📝 升级说明
+
+从旧版本升级的用户请注意：
+
+1. **向后兼容性**: 旧的 Basic Auth 已被移除，必须配置 API Key
+2. **数据迁移**: 无需迁移数据，只需更新配置
+3. **首次配置**: 首次启动时会提示生成 API Key
+
+## 🆘 紧急访问
+
+如果忘记密码或无法访问管理后台：
+
+1. 直接修改 `data.json` 中的 `api_keys` 配置
+2. 重启服务
+3. 使用新的 API Key 登录
+
+## 📊 监控和日志
+
+服务器会记录以下认证相关日志：
+
+- `[认证] 登录成功`: API Key 验证成功
+- `[认证] 登录失败`: API Key 验证失败
+- `[认证] Token 验证通过`: Token 验证成功
+- `[认证] Token 验证失败`: Token 过期或无效
+
+查看日志：
+```bash
+journalctl -u telegram-bot-api -f
+# 或
+tail -f /path/to/your/log/file
+```
+
+## 🔗 相关资源
+
+- [JWT 官方文档](https://jwt.io/)
+- [OWASP 认证指南](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
+- [API Key 最佳实践](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens)
+
+---
+
+## <a id="file-4-changelogmd"></a>CHANGELOG.md
+
+# 更新日志
+
+## [2.1.0] - 2026-03-11
+
+### 🔧 Bug Fixes
+
+#### ✅ 修复 JWT 认证关键问题
+
+**P2 Badge: JWT Signing Key Persist Across Restarts**
+- **问题**: JWT 签名密钥在每次服务重启时重新生成，导致所有 Token 失效
+- **解决方案**: 
+  - 新增 `initJWTSecret()` 函数
+  - JWT 密钥持久化到 `jwt_secret.key` 文件
+  - 启动时自动加载已存在的密钥
+- **影响**: 
+  - ✅ Token 在服务重启后仍然有效（2 小时有效期内）
+  - ✅ 支持多实例部署
+  - ✅ 避免用户意外登出
+
+**P2 Badge: Expose /admin.html without JWT Gate**
+- **问题**: `/admin.html` 被 JWT 中间件拦截，导致登录页面无法访问
+- **解决方案**:
+  - 移除 `/admin.html` 的 JWT 认证中间件
+  - 作为公开页面提供（登录入口）
+  - 其他管理 API 保持 JWT 认证
+- **影响**:
+  - ✅ 用户可以直接访问登录页面
+  - ✅ 正常的登录流程得以恢复
+  - ✅ 保持了其他 API 的安全性
+
+### 📁 文件变更
+
+**修改的文件**:
+- `main.go` - 实现 JWT 密钥持久化和路由修复
+- `.gitignore` - 已有 `*.key` 规则保护密钥文件
+
+**新增的文件**:
+- `jwt_secret.key` - JWT 签名密钥文件（运行时自动生成）
+- `JWT_FIXES.md` - 详细的修复技术文档
+- `P2_BADGE_FIX_SUMMARY.md` - 完整的修复总结
+- `verify-jwt-fix.sh` - Bash 验证脚本
+- `verify-jwt-fix.ps1` - PowerShell 验证脚本
+
+### 🔒 安全性
+
+- JWT 密钥文件权限设置为 `0600`（仅所有者可读写）
+- 密钥文件已添加到 `.gitignore`，避免提交到版本控制
+- 生产环境建议使用环境变量或密钥管理服务
+
+### 📊 技术细节
+
+**JWT 密钥初始化流程**:
+```go
+func initJWTSecret() {
+    jwtSecretFile := "jwt_secret.key"
+    
+    // 尝试读取已存在的密钥
+    if data, err := os.ReadFile(jwtSecretFile); err == nil {
+        jwtSecret = data
+        return
+    }
+    
+    // 生成新密钥并保存
+    jwtSecret = generateJWTSecret()
+    os.WriteFile(jwtSecretFile, jwtSecret, 0600)
+}
+```
+
+**路由认证配置**:
+```go
+// 公开路由（登录页面）
+mux.HandleFunc("/admin.html", serveAdminPage)
+
+// 受保护的路由（需要 JWT）
+mux.HandleFunc("/api/stats", jwtAuthMiddleware(statsHandler))
+// ... 其他 API
+```
+
+### 🚀 升级指南
+
+**全新安装**:
+1. 直接运行程序，自动生成 `jwt_secret.key`
+2. 无需额外配置
+
+**从 v2.0 升级**:
+1. 停止当前服务
+2. 更新代码到 v2.1.0
+3. 重新启动服务（自动生成新密钥文件）
+4. **注意**: 升级后所有用户的 Token 会失效，需要重新登录
+
+### ✅ 验证清单
+
+- [x] JWT 密钥持久化功能正常
+- [x] `/admin.html` 可以正常访问
+- [x] 登录后能够获取 Token
+- [x] 重启服务后 Token 仍然有效
+- [x] 密钥文件不会被 Git 跟踪
+
+### 📝 相关文档
+
+- [详细修复说明](./JWT_FIXES.md)
+- [完整总结](./P2_BADGE_FIX_SUMMARY.md)
+- [认证指南](./AUTH_GUIDE.md)
+
+---
+
+## [2.0.0] - 2026-03-XX
+
+### ✨ 新功能
+
+- 🔐 JWT 认证系统
+  - API Key + Token 双重认证
+  - Token 有效期 2 小时
+  - 自动续期机制
+- 🎨 全新管理后台界面
+  - 优雅的登录页面
+  - Token 本地存储
+  - 401 自动登出
+- 📊 增强统计功能
+- 🚫 IP 封禁管理
+
+### 🔧 改进
+
+- 从 Basic Auth 迁移到 JWT 认证
+- 支持多 API Key 配置
+- 更安全的凭据管理
+
+---
+
+## [1.0.0] - 初始版本
+
+### ✨ 基础功能
+
+- 📤 文件上传到 Telegram
+- 🎨 Web 上传界面
+- 💾 MySQL 数据库支持
+- 🔄 缓存管理
+- 🚫 基础 IP 封禁功能
+
+---
+
+## <a id="file-5-debian12_deploymd"></a>DEBIAN12_DEPLOY.md
+
+# 文档已合并
+
+本文件内容已合并至项目主说明文档 `README.md`，请改为阅读：
+
+- `README.md` -> `统一说明（已合并）`
+- `README.md` -> `更新日志（主说明文件）`
+- `README.md` -> `保留数据迁移流程`
+
+---
+
+## <a id="file-6-deployment_checklistmd"></a>DEPLOYMENT_CHECKLIST.md
+
+# 管理后台认证升级 - 部署检查清单
+
+## ✅ 升级完成项
+
+- [x] 后端 JWT 认证实现 (main.go)
+  - [x] 添加 JWT 依赖 (github.com/golang-jwt/jwt/v5)
+  - [x] 扩展配置结构体 (api_keys 字段)
+  - [x] 实现 JWT token 生成和验证工具函数
+  - [x] 实现 /api/login 接口
+  - [x] 实现 /api/verify 接口
+  - [x] 实现 JWT 认证中间件
+  - [x] 移除旧的 Basic Auth 中间件
+
+- [x] 前端登录界面实现 (admin/index.html)
+  - [x] 登录页面 UI
+  - [x] Token 管理功能 (localStorage)
+  - [x] 自动请求拦截器
+  - [x] 401 自动登出处理
+  - [x] 登出按钮和功能
+
+- [x] 配置文件更新
+  - [x] data.json.example 添加 api_keys 示例
+  - [x] 配置文件加载验证逻辑
+
+- [x] 辅助工具
+  - [x] generate-api-key.sh (Linux/Mac)
+  - [x] generate-api-key.ps1 (Windows)
+  - [x] AUTH_GUIDE.md 配置指南
+  - [x] go.mod 依赖更新
+
+## 📋 部署步骤
+
+### 1. 安装依赖
+
+```bash
+cd "d:\xiangmu\TG图床"
+go mod tidy
+```
+
+### 2. 生成 API Key
+
+#### Windows PowerShell:
+```powershell
+.\generate-api-key.ps1
+```
+
+复制生成的 API Key，例如：
+```
+a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6
+```
+
+### 3. 配置 data.json
+
+编辑 `data.json` 文件（如果不存在则从 data.json.example 复制）：
+
+```json
+{
+  "telegram": {
+    "bot_token": "YOUR_BOT_TOKEN",
+    "channel_id": "-1001234567890"
+  },
+  "mysql": {
+    "host": "localhost",
+    "port": 3306,
+    "username": "tg_imagebed",
+    "password": "your_password",
+    "database": "tg_imagebed"
+  },
+  "admin": {
+    "user_ids": [123456789, 987654321]
+  },
+  "api_keys": [
+    "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6"
+  ]
+}
+```
+
+**注意**: 将上面的示例 API Key 替换为你实际生成的值。
+
+### 4. 编译和测试
+
+```bash
+# 编译
+go build -o tg-upload.exe main.go
+
+# 或者运行测试
+go run main.go
+```
+
+### 5. 重启服务
+
+```powershell
+# 停止现有服务
+.\stop.sh
+
+# 启动新服务
+.\start.sh
+
+# 或者如果使用 systemd (Linux)
+sudo systemctl restart telegram-bot-api
+```
+
+### 6. 验证登录
+
+1. 打开浏览器访问：`http://localhost:8080/admin.html`
+2. 输入配置的 API Key
+3. 点击登录
+4. 验证是否能正常访问管理后台
+
+## 🔍 验证检查点
+
+### 后端验证
+
+- [ ] 服务启动日志显示 "已加载 X 个 API Key"
+- [ ] 访问 `/api/login` 接口正常响应
+- [ ] 使用正确 API Key 能获取到 token
+- [ ] 使用错误 API Key 返回 401 错误
+- [ ] 携带有效 token 能访问受保护的 API
+- [ ] 携带无效 token 返回 401 错误
+
+### 前端验证
+
+- [ ] 首次访问自动跳转到登录页
+- [ ] 输入 API Key 能成功登录
+- [ ] 登录后能正常显示统计数据
+- [ ] 文件列表能正常加载
+- [ ] IP 封禁功能正常工作
+- [ ] 文件删除功能正常工作
+- [ ] 点击"退出登录"能返回登录页
+- [ ] 刷新页面后保持登录状态
+- [ ] Token 过期后自动跳转登录页
+
+## 🐛 常见问题
+
+### 问题 1: 编译失败
+
+**错误信息**: `package github.com/golang-jwt/jwt/v5: cannot find package`
+
+**解决方案**:
+```bash
+go mod tidy
+go get github.com/golang-jwt/jwt/v5@v5.2.0
+```
+
+### 问题 2: 登录提示 "API Key 无效"
+
+**检查项**:
+1. data.json 中是否配置了 api_keys
+2. API Key 是否与生成的一致（无多余空格）
+3. 服务是否已重启
+
+### 问题 3: 登录后立即被退出
+
+**检查项**:
+1. 浏览器控制台是否有 401 错误
+2. 服务器时间是否准确
+3. 清除浏览器缓存重试
+
+### 问题 4: 无法访问 /api/login
+
+**检查项**:
+1. 服务是否正常启动
+2. 端口是否正确（默认 8080）
+3. 防火墙设置
+
+## 📝 回滚方案
+
+如果需要回滚到旧版本：
+
+1. 备份当前的 main.go 和 admin/index.html
+2. 恢复旧版本文件
+3. 重启服务
+
+**注意**: 旧版本使用 Basic Auth，需要重新配置用户名密码。
+
+## 🎯 下一步优化建议
+
+- [ ] 添加 token 刷新接口（当前 token 过期需重新登录）
+- [ ] 添加登录日志记录
+- [ ] 支持 token 黑名单机制
+- [ ] 添加双因素认证 (2FA)
+- [ ] 支持 OAuth2 第三方登录
+- [ ] 添加密码强度检测
+- [ ] 实现 API Key 轮换机制
+
+## 📞 技术支持
+
+如遇到问题，请查看：
+
+1. [AUTH_GUIDE.md](./AUTH_GUIDE.md) - 详细配置指南
+2. 服务器日志：`journalctl -u telegram-bot-api -f`
+3. 浏览器控制台错误信息
+
+---
+
+## <a id="file-7-get_channel_idmd"></a>GET_CHANNEL_ID.md
+
+# 文档已合并
+
+本文件内容已合并至项目主说明文档 `README.md`，请改为阅读：
+
+- `README.md` -> `统一说明（已合并）`
+- `README.md` -> `更新日志（主说明文件）`
+- `README.md` -> `保留数据迁移流程`
+
+---
+
+## <a id="file-8-implementation_summarymd"></a>IMPLEMENTATION_SUMMARY.md
+
+# 管理后台认证优化 - 实施总结
+
+## ✅ 已完成任务
+
+### 1. 后端实现 (main.go)
+
+#### 依赖添加
+- ✅ `github.com/golang-jwt/jwt/v5` - JWT 认证库
+- ✅ `crypto/sha256` - SHA-256 哈希
+- ✅ `encoding/hex` - 十六进制编码
+
+#### 配置结构扩展
+```go
+type Config struct {
+    // ... 现有字段
+    APIKeys []string `json:"api_keys"` // API Key 列表
+}
+```
+
+#### 核心函数实现
+
+**JWT 工具函数**:
+- `generateJWTSecret()` - 生成 JWT 签名密钥
+- `hashAPIKey(key string)` - API Key SHA-256 哈希
+- `validateAPIKey(apiKey string)` - 验证 API Key 有效性
+- `generateToken(apiKey string)` - 生成 JWT Token
+- `validateToken(tokenString string)` - 验证 JWT Token
+- `validateAPIKeyHash(hashedKey string)` - 验证 API Key Hash
+
+**API 接口**:
+- `POST /api/login` - 登录接口，验证 API Key 并返回 Token
+- `GET /api/verify` - Token 验证接口
+- `jwtAuthMiddleware` - JWT 认证中间件（替代 Basic Auth）
+
+**移除内容**:
+- ❌ `adminAuthMiddleware` - 旧的 Basic Auth 中间件
+- ❌ `adminUser` 和 `adminPass` 硬编码变量
+
+#### 日志输出优化
+```
+[认证] JWT Token 认证已启用（有效期：2h0m0s）
+[安全提示] 请在 data.json 中配置 api_keys，使用强随机密钥
+[配置] 已加载 X 个 API Key
+```
+
+### 2. 前端实现 (admin/index.html)
+
+#### UI 组件
+
+**登录页面**:
+- ✅ 全屏渐变背景登录框
+- ✅ API Key 密码输入框
+- ✅ 登录按钮和错误提示
+- ✅ 响应式设计
+
+**主界面**:
+- ✅ 退出登录按钮（Header 右上角）
+- ✅ 登录状态自动检测
+
+#### JavaScript 功能模块
+
+**Token 管理**:
+```javascript
+getToken()        // 从 localStorage 读取 Token
+saveToken(token)  // 保存 Token 到 localStorage
+removeToken()     // 清除 Token
+checkAuth()       // 检查认证状态
+```
+
+**登录处理**:
+```javascript
+handleLogin(event)  // 处理登录表单提交
+logout()            // 处理登出操作
+verifyToken(token)  // 验证 Token 有效性
+```
+
+**请求拦截器**:
+```javascript
+requestJSON(url, options)
+// - 自动附加 Authorization: Bearer <token>
+// - 处理 401 错误并自动跳转登录
+```
+
+#### 样式增强
+- ✅ 登录页面专用 CSS（90+ 行）
+- ✅ Header 操作按钮样式
+- ✅ 响应式布局适配
+
+### 3. 配置文件更新
+
+#### data.json.example
+```json
+{
+  "api_keys": [
+    "your-secret-api-key-here-change-this-in-production"
+  ]
+}
+```
+
+**配置说明新增**:
+- API Key 生成方法：`openssl rand -hex 32`
+- 最佳实践建议
+- 多管理员配置示例
+
+#### go.mod
+```go
+require (
+    github.com/golang-jwt/jwt/v5 v5.2.0
+)
+```
+
+### 4. 辅助工具
+
+#### generate-api-key.sh (Linux/Mac)
+- 使用 OpenSSL 生成 32 字节随机 Key
+- 输出格式化使用说明
+- 可执行权限：`chmod +x`
+
+#### generate-api-key.ps1 (Windows)
+- PowerShell 版本生成脚本
+- 使用 .NET 加密随机数生成器
+- 彩色终端输出
+
+#### AUTH_GUIDE.md
+- 完整的配置指南
+- 故障排查手册
+- 安全最佳实践
+- 180+ 行详细文档
+
+#### DEPLOYMENT_CHECKLIST.md
+- 分步部署清单
+- 验证检查点
+- 常见问题解答
+- 回滚方案
+
+#### UPGRADE_README.md
+- 升级说明和迁移指南
+- 新旧版本对比表
+- 性能影响分析
+- 后续优化计划
+
+## 📊 技术指标
+
+### 代码变更统计
+
+| 文件 | 新增行数 | 删除行数 | 修改内容 |
+|------|---------|---------|---------|
+| main.go | ~220 | ~30 | JWT 认证实现 |
+| admin/index.html | ~250 | ~5 | 登录 UI 和逻辑 |
+| go.mod | 1 | 0 | 依赖添加 |
+| data.json.example | 10 | 0 | API Keys 配置 |
+| **总计** | **~481** | **~35** | - |
+
+### 新增文件统计
+
+| 文件 | 行数 | 用途 |
+|------|------|------|
+| generate-api-key.sh | 30 | Linux/Mac Key 生成 |
+| generate-api-key.ps1 | 31 | Windows Key 生成 |
+| AUTH_GUIDE.md | 180 | 配置指南 |
+| DEPLOYMENT_CHECKLIST.md | 193 | 部署清单 |
+| UPGRADE_README.md | 178 | 升级说明 |
+| **总计** | **612** | - |
+
+## 🔐 安全增强
+
+### 改进对比
+
+| 方面 | 改进前 | 改进后 |
+|------|--------|--------|
+| 凭据存储 | 代码硬编码 | 配置文件 + Hash |
+| 传输方式 | 明文密码（每次请求） | JWT Token（2 小时） |
+| 过期机制 | 永久有效 | 自动过期 |
+| 多用户 | 单账户 | 多 API Key |
+| 登出功能 | ❌ 不支持 | ✅ 支持 |
+| 暴力破解 | 易受攻击 | Hash 防护 |
+
+### OWASP 合规性
+
+✅ **A01: 访问控制失效** - 已修复
+- 实现基于 Token 的访问控制
+- 自动 401 处理和重定向
+
+✅ **A02: 认证失效** - 已修复
+- 强随机 API Key
+- Token 有效期限制
+- Hash 存储凭据
+
+✅ **A07: 身份识别失败** - 已修复
+- 详细的认证日志
+- Token 验证记录
+
+## 🎯 功能特性
+
+### 核心功能
+- ✅ API Key 配置化管理
+- ✅ JWT Token 生成和验证
+- ✅ 2 小时 Token 有效期
+- ✅ 自动 Token 续期检测
+- ✅ 401 自动登出
+- ✅ 多 API Key 支持
+- ✅ 优雅的登录界面
+- ✅ 一键登出功能
+
+### 用户体验
+- ✅ 持久化登录状态
+- ✅ 无感 Token 验证
+- ✅ 友好的错误提示
+- ✅ 响应式设计
+- ✅ 现代化 UI
+
+## 📝 部署要求
+
+### 系统要求
+- Go 1.19+
+- 浏览器支持 localStorage
+- HTTPS（生产环境推荐）
+
+### 依赖安装
+```bash
+go mod tidy
+```
+
+### 配置步骤
+1. 生成 API Key: `./generate-api-key.ps1`
+2. 配置 data.json: 添加 api_keys 数组
+3. 重启服务：`./restart.sh`
+4. 验证登录：访问 `/admin.html`
+
+## 🔄 兼容性说明
+
+### 向后兼容
+- ❌ 不兼容旧版 Basic Auth
+- ✅ 数据库结构无需变更
+- ✅ 现有文件数据不受影响
+- ✅ API 接口保持不变（除认证方式）
+
+### 迁移注意
+- ⚠️ 必须配置 API Key 才能访问后台
+- ⚠️ 旧的用户名密码不再有效
+- ⚠️ 需要手动更新配置文件
+
+## 🎨 界面对比
+
+### 登录流程
+
+**改进前**:
+```
+访问 /admin.html → 浏览器弹窗 → 输入用户名密码 → 确定
+```
+
+**改进后**:
+```
+访问 /admin.html → 显示登录页面 → 输入 API Key → 点击登录 → 进入后台
+```
+
+### 认证提示
+
+**改进前**:
+```
+浏览器原生弹窗："请输入用户名和密码"
+```
+
+**改进后**:
+```
+自定义登录页面："请输入 API Key 进行认证"
+```
+
+## 📈 性能指标
+
+### 基准测试（预估）
+
+| 操作 | 耗时 | 内存 |
+|------|------|------|
+| Token 生成 | < 1ms | < 1KB |
+| Token 验证 | < 0.5ms | < 0.5KB |
+| API Key 验证 | < 0.3ms | < 0.3KB |
+| 登录请求 | < 50ms | - |
+
+### 并发影响
+- 连接池：保持 50 不变
+- 最大连接：保持 10 不变
+- 无明显性能下降
+
+## 🚀 后续优化方向
+
+### 短期（1-2 周）
+- [ ] Token 刷新接口（无需重新登录）
+- [ ] 登录日志记录到数据库
+- [ ] Token 黑名单机制
+
+### 中期（1-2 月）
+- [ ] 双因素认证 (2FA)
+- [ ] 密码强度检测
+- [ ] API Key 轮换机制
+
+### 长期（3-6 月）
+- [ ] OAuth2 第三方登录
+- [ ] 基于角色的访问控制 (RBAC)
+- [ ] 审计日志系统
+
+## ✅ 验收标准
+
+### 功能验收
+- [x] 能正常生成和配置 API Key
+- [x] 能使用 API Key 成功登录
+- [x] Token 能正常生成和验证
+- [x] 过期 Token 自动拒绝
+- [x] 登出功能正常工作
+- [x] 所有管理功能正常使用
+
+### 安全验收
+- [x] API Key Hash 存储
+- [x] Token 有效期限制
+- [x] 401 自动处理
+- [x] 无明文密码传输
+- [x] 防止暴力破解
+
+### 性能验收
+- [x] 响应时间 < 100ms
+- [x] 并发能力不受影响
+- [x] 内存占用无明显增加
+
+## 📞 相关资源
+
+- JWT 官方文档：https://jwt.io/
+- OWASP 认证指南：https://cheatsheetseries.owasp.org/
+- golang-jwt 库：https://github.com/golang-jwt/jwt
+
+---
+
+**实施完成日期**: 2026-03-11  
+**实施人员**: AI Assistant  
+**版本**: v2.0  
+**状态**: ✅ 已完成
+
+---
+
+## <a id="file-9-jwt_fixesmd"></a>JWT_FIXES.md
+
+# JWT 认证修复说明
+
+## 🔧 修复内容
+
+### 问题 1：JWT Signing Key 在重启后不持久化
+
+**问题描述**：
+- 之前每次服务重启时，`generateJWTSecret()` 都会生成新的随机密钥
+- 导致之前颁发的所有 JWT Token 立即失效（即使在 2 小时有效期内）
+- 用户会被意外登出，负载均衡场景下会出现认证失败
+
+**解决方案**：
+- ✅ 新增 `initJWTSecret()` 函数
+- ✅ 首次启动时生成密钥并保存到 `jwt_secret.key` 文件
+- ✅ 后续启动时从文件加载已存在的密钥
+- ✅ 密钥文件权限设置为 `0600`（仅所有者可读写）
+
+**影响**：
+- ✅ Token 在服务重启后仍然有效（在 2 小时有效期内）
+- ✅ 支持多实例部署（需要共享 `jwt_secret.key` 文件）
+- ✅ 提高用户体验，避免意外登出
+
+### 问题 2：`/admin.html` 被 JWT 中间件拦截
+
+**问题描述**：
+- `/admin.html` 被 `jwtAuthMiddleware` 拦截
+- 初次访问时浏览器还没有 Token，直接返回 401
+- 用户无法看到登录页面，形成死循环
+
+**解决方案**：
+- ✅ 移除 `/admin.html` 的 JWT 认证中间件
+- ✅ `/admin.html` 作为公开页面，允许任何人访问
+- ✅ 其他管理 API（`/api/*`）仍然需要 JWT 认证
+- ✅ 前端通过 Token 检测自动显示登录页面或主界面
+
+**认证流程**：
+```
+1. 用户访问 /admin.html
+   ↓
+2. 服务器返回登录页面（无需认证）
+   ↓
+3. 前端检查 localStorage 中的 Token
+   ↓
+4. 如果有 Token 且有效 → 显示主界面
+   ↓
+5. 如果无 Token 或无效 → 显示登录页面
+```
+
+## 📁 新增文件
+
+- `jwt_secret.key` - JWT 签名密钥文件（自动生成，已加入 .gitignore）
+
+## 🔒 安全建议
+
+1. **生产环境部署**：
+   - 建议将 `jwt_secret.key` 存储在安全的位置（如环境变量、密钥管理服务）
+   - 多实例部署时需要共享同一个密钥文件
+
+2. **密钥轮换**：
+   - 定期更换 `jwt_secret.key` 文件（例如每月）
+   - 更换后所有旧 Token 会立即失效，用户需要重新登录
+
+3. **文件权限**：
+   - 确保 `jwt_secret.key` 文件权限为 `0600`
+   - 仅允许应用运行用户读取
+
+## 🚀 升级步骤
+
+### 全新安装
+1. 直接运行程序，会自动生成 `jwt_secret.key`
+2. 无需任何额外配置
+
+### 从旧版本升级
+1. 停止当前运行的服务
+2. 更新代码到最新版本
+3. 重新启动服务
+4. 首次启动会自动生成 `jwt_secret.key`
+
+**注意**：升级后所有用户的 Token 会失效，需要重新登录。
+
+## 📊 技术细节
+
+### JWT 密钥初始化流程
+
+```go
+func initJWTSecret() {
+    jwtSecretFile := "jwt_secret.key"
+    
+    // 1. 尝试读取已存在的密钥文件
+    if data, err := os.ReadFile(jwtSecretFile); err == nil {
+        jwtSecret = data
+        log.Printf("[认证] 已加载 JWT 密钥文件：%s", jwtSecretFile)
+        return
+    }
+    
+    // 2. 生成新密钥并保存到文件
+    jwtSecret = generateJWTSecret()
+    if err := os.WriteFile(jwtSecretFile, jwtSecret, 0600); err != nil {
+        log.Printf("[警告] 保存 JWT 密钥文件失败：%v", err)
+    } else {
+        log.Printf("[认证] 已生成并保存 JWT 密钥文件：%s", jwtSecretFile)
+    }
+}
+```
+
+### 路由认证配置
+
+```go
+// 公开路由（无需认证）
+mux.HandleFunc("/admin.html", func(w http.ResponseWriter, r *http.Request) {
+    http.ServeFile(w, r, "admin/index.html")
+})
+
+// 受保护的路由（需要 JWT 认证）
+mux.HandleFunc("/api/stats", jwtAuthMiddleware(statsHandler))
+mux.HandleFunc("/api/files", jwtAuthMiddleware(filesHandler))
+mux.HandleFunc("/api/banned", jwtAuthMiddleware(bannedListHandler))
+// ... 其他 API
+```
+
+## ✅ 验证清单
+
+- [ ] 服务启动后检查日志，确认 JWT 密钥已生成或加载
+- [ ] 访问 `/admin.html` 能够正常显示登录页面
+- [ ] 使用正确的 API Key 登录后能够访问管理界面
+- [ ] 关闭并重新启动服务，确认之前的 Token 仍然有效
+- [ ] 检查 `jwt_secret.key` 文件是否存在且权限正确
+
+## 🐛 故障排查
+
+### 问题：重启后 Token 仍然失效
+
+**可能原因**：
+- `jwt_secret.key` 文件没有被正确保存
+- 文件权限问题导致无法读取
+
+**解决方法**：
+1. 检查 `jwt_secret.key` 文件是否存在
+2. 检查文件权限：`ls -l jwt_secret.key`
+3. 查看启动日志中的认证信息
+
+### 问题：无法访问 `/admin.html`
+
+**可能原因**：
+- 反向代理配置问题
+- 文件路径错误
+
+**解决方法**：
+1. 检查 `admin/index.html` 文件是否存在
+2. 检查服务器日志
+3. 尝试直接访问 `http://localhost:8080/admin.html`
+
+## 📞 获取帮助
+
+如有问题，请查看项目文档或提交 Issue。
+
+---
+
+## <a id="file-10-migrate_guidemd"></a>MIGRATE_GUIDE.md
+
+# 数据库迁移指南
+
+## 📋 概述
+
+本指南帮助您将旧版本的TG图床数据迁移到新的数据库结构，新增 `delete_reason` 字段用于记录文件删除原因。
+
+## ✨ 新增功能
+
+**delete_reason 字段**:
+- **类型**: VARCHAR(500)
+- **说明**: 记录文件被删除的原因
+- **默认值**: NULL（为空）
+- **位置**: files 表中 status 字段之后
+
+## 🚀 迁移方法
+
+### 方法1：使用Python脚本（推荐）
+
+```bash
+# 1. 确保已安装依赖
+pip install pymysql
+
+# 2. 执行迁移脚本
+python3 migrate.py
+```
+
+### 方法2：使用Shell脚本
+
+```bash
+# 1. 确保已配置 data.json
+cp data.json.example data.json
+nano data.json
+
+# 2. 执行迁移脚本
+chmod +x migrate-data.sh
+./migrate-data.sh
+```
+
+### 方法3：手动执行SQL
+
+```sql
+-- 直接在数据库中执行
+ALTER TABLE files
+ADD COLUMN delete_reason VARCHAR(500) DEFAULT NULL
+COMMENT '删除原因'
+AFTER status;
+```
+
+## 📊 迁移流程
+
+### 迁移前检查
+
+- [ ] 确认 `data.json` 配置文件存在
+- [ ] 确认数据库连接信息正确
+- [ ] 确认 `files` 表已存在
+- [ ] 确认有足够的磁盘空间用于备份
+- [ ] （可选）备份整个数据库
+
+### 执行迁移
+
+1. **连接测试** - 脚本会测试数据库连接
+2. **字段检测** - 检查是否需要迁移
+3. **数据备份** - 自动创建 `.sql` 备份文件
+4. **字段添加** - 添加 `delete_reason` 字段
+5. **验证成功** - 确认字段已添加
+6. **显示结果** - 显示表结构和数据统计
+
+### 迁移后验证
+
+- [ ] 检查备份文件已创建
+- [ ] 检查 `delete_reason` 字段存在
+- [ ] 检查现有数据保持不变
+- [ ] 测试应用程序删除功能
+- [ ] 验证新字段可正常写入
+
+## 🔄 迁移脚本说明
+
+### migrate.py (Python脚本）
+
+**优点**:
+- ✅ 适合 Linux/macOS 服务器环境
+- ✅ 详细的错误处理
+- ✅ 自动备份数据库
+- ✅ 友好的输出信息
+- ✅ 失败时自动回滚
+
+**缺点**:
+- 需要 Python 3.x
+- 需要 pymysql 库
+
+### migrate-data.sh (Shell脚本）
+
+**优点**:
+- ✅ 不需要额外依赖
+- ✅ 直接使用 MySQL 命令
+- ✅ 自动创建备份
+- ✅ 失败时自动恢复
+
+**缺点**:
+- 依赖 bash 和 mysqldump
+
+## 📁 备份文件
+
+迁移脚本会自动创建备份文件，命名格式：
+
+```
+backup_YYYYMMDD_HHMMSS.sql
+```
+
+示例：
+```
+backup_20260216_183045.sql
+```
+
+## 🔙 回滚方法
+
+如果迁移后出现问题，可以使用备份回滚：
+
+### 方法1：使用备份文件
+
+```bash
+# Linux/macOS
+mysql -h localhost -P 3306 -u username -p database_name < backup_20260216_183045.sql
+```
+
+### 方法2：删除新增字段
+
+```sql
+-- 删除 delete_reason 字段
+ALTER TABLE files DROP COLUMN delete_reason;
+```
+
+## 📋 迁移后的影响
+
+### 应用程序影响
+
+- **旧数据**: 现有文件的 `delete_reason` 字段为 NULL
+- **新数据**: 删除文件时可以填写删除原因
+- **API影响**: 新增参数需要 `delete_reason`
+
+### 代码更新
+
+需要更新的代码文件：
+
+1. **main.go**
+   - `DeleteHandler` 需要接收 `delete_reason`
+   - 数据库更新时写入删除原因
+
+2. **bot/database.py**
+   - `delete_file_by_path` 函数需要更新
+
+3. **前端界面**
+   - 删除确认对话框添加"删除原因"输入框
+
+### 示例代码更新
+
+```go
+// main.go
+type DeleteRequest struct {
+    Path        string `json:"path"`
+    Reason      string `json:"reason"`  // 新增
+}
+```
+
+```python
+// bot/database.py
+def delete_file_by_path(self, random_path: str, reason: str = "") -> Tuple[bool, str]:
+    # 使用 reason 参数
+    pass
+```
+
+## ✅ 验证清单
+
+迁移完成后，请验证以下项目：
+
+### 数据库验证
+
+```sql
+-- 检查字段是否存在
+SHOW COLUMNS FROM files LIKE 'delete_reason';
+
+-- 查看表结构
+DESC files;
+
+-- 查看数据统计
+SELECT
+    status,
+    COUNT(*) as count,
+    COUNT(CASE WHEN delete_reason IS NULL THEN 1 END) as no_reason
+FROM files
+GROUP BY status;
+```
+
+### 功能验证
+
+- [ ] 可以正常上传文件
+- [ ] 可以正常访问文件
+- [ ] 删除功能正常工作
+- [ ] 删除原因可以填写和保存
+- [ ] 管理后台正常显示
+- [ ] API 接口正常响应
+
+## 🚨 常见问题
+
+### Q1: 脚本提示"配置文件不存在"
+
+**A**: 复制配置模板
+```bash
+cp data.json.example data.json
+nano data.json  # 编辑配置
+```
+
+### Q2: 脚本提示"数据库连接失败"
+
+**A**: 检查配置文件中的数据库信息
+```json
+{
+  "mysql": {
+    "host": "localhost",
+    "port": 3306,
+    "username": "your_username",
+    "password": "your_password",
+    "database": "your_database"
+  }
+}
+```
+
+### Q3: 提示"字段已存在，无需迁移"
+
+**A**: 说明数据库已经是最新结构，无需迁移。
+
+### Q4: 迁移后应用程序报错
+
+**A**:
+1. 检查应用程序代码是否已更新
+2. 重启应用程序
+3. 检查日志文件
+4. 如有问题，使用备份回滚
+
+### Q5: 备份文件创建失败
+
+**A**:
+1. 检查磁盘空间
+2. 检查 mysqldump 是否已安装
+3. 检查文件写入权限
+4. 手动备份数据库
+
+## 📞 技术支持
+
+如遇到问题，请：
+
+1. 查看迁移脚本的详细错误信息
+2. 检查 MySQL 错误日志
+3. 检查应用程序日志
+4. 查看项目文档
+
+## 🎯 下一步
+
+迁移完成后：
+
+1. ✅ 测试应用程序的所有功能
+2. ✅ 更新相关文档
+3. ✅ 通知团队成员数据库结构变更
+4. ✅ 更新开发环境
+5. ✅ 部署到生产环境
+
+---
+
+**迁移脚本文件**:
+- `migrate.py` - Python脚本（推荐）
+- `migrate-data.sh` - Shell脚本
+
+**建议使用**: Python脚本 `migrate.py`
+
+---
+
+## <a id="file-11-p2_badge_fix_summarymd"></a>P2_BADGE_FIX_SUMMARY.md
+
+# P2 Badge 修复总结
+
+## 📋 问题概述
+
+本次修复解决了 JWT 认证系统中的两个关键问题：
+
+### ❌ 问题 1：JWT Signing Key 在重启后不持久化
+
+**症状**：
+- 每次服务重启，所有已颁发的 Token 立即失效
+- 用户被意外登出，即使在 Token 有效期内
+- 负载均衡部署时出现认证失败
+
+**根本原因**：
+```go
+// 旧代码：每次启动都生成新密钥
+jwtSecret = generateJWTSecret() // 在包初始化时执行
+```
+
+### ❌ 问题 2：`/admin.html` 被 JWT 中间件拦截
+
+**症状**：
+- 访问 `/admin.html` 直接返回 401 错误
+- 登录页面无法显示
+- 用户无法进行登录操作
+
+**根本原因**：
+```go
+// 旧代码：对登录页面应用了 JWT 认证
+mux.HandleFunc("/admin.html", jwtAuthMiddleware(func(w http.ResponseWriter, r *http.Request) {
+    http.ServeFile(w, r, "admin/index.html")
+}))
+```
+
+---
+
+## ✅ 解决方案
+
+### 🔧 修复 1：JWT 密钥持久化
+
+**实现思路**：
+1. 首次启动时生成密钥并保存到文件
+2. 后续启动时从文件加载已存在的密钥
+3. 密钥文件使用安全权限（0600）
+
+**代码实现**：
+```go
+// initJWTSecret 初始化 JWT 密钥（从配置文件加载或生成后保存）
+func initJWTSecret() {
+    jwtSecretFile := "jwt_secret.key"
+    
+    // 1. 尝试读取已存在的密钥文件
+    if data, err := os.ReadFile(jwtSecretFile); err == nil {
+        jwtSecret = data
+        log.Printf("[认证] 已加载 JWT 密钥文件：%s", jwtSecretFile)
+        return
+    }
+    
+    // 2. 生成新密钥并保存到文件
+    jwtSecret = generateJWTSecret()
+    if err := os.WriteFile(jwtSecretFile, jwtSecret, 0600); err != nil {
+        log.Printf("[警告] 保存 JWT 密钥文件失败：%v，重启后 Token 将失效", err)
+    } else {
+        log.Printf("[认证] 已生成并保存 JWT 密钥文件：%s", jwtSecretFile)
+    }
+}
+```
+
+**调用时机**：
+```go
+func main() {
+    loadConfig()
+    if err := initDB(); err != nil {
+        log.Fatalf("数据库初始化失败：%v", err)
+    }
+    
+    // ... 其他初始化 ...
+    
+    // 初始化或加载 JWT 密钥
+    initJWTSecret()
+    
+    // ... 启动服务器 ...
+}
+```
+
+### 🔧 修复 2：移除 `/admin.html` 的 JWT 中间件
+
+**实现思路**：
+1. `/admin.html` 作为公开页面（登录入口）
+2. 其他管理 API 保持 JWT 认证
+3. 前端自动检测 Token 状态并显示相应界面
+
+**代码实现**：
+```go
+// 管理后台 API 路由
+// /admin.html 不需要认证（登录页面）
+mux.HandleFunc("/admin.html", func(w http.ResponseWriter, r *http.Request) {
+    http.ServeFile(w, r, "admin/index.html")
+})
+
+// 其他管理 API 需要 JWT 认证
+mux.HandleFunc("/api/stats", jwtAuthMiddleware(statsHandler))
+mux.HandleFunc("/api/files", jwtAuthMiddleware(filesHandler))
+mux.HandleFunc("/api/banned", jwtAuthMiddleware(bannedListHandler))
+// ... 其他 API
+```
+
+---
+
+## 📁 修改的文件
+
+### 1. `main.go`
+- ✅ 修改 `jwtSecret` 变量声明（从初始化表达式改为空声明）
+- ✅ 新增 `initJWTSecret()` 函数
+- ✅ 在 `main()` 中调用 `initJWTSecret()`
+- ✅ 移除 `/admin.html` 的 `jwtAuthMiddleware`
+
+### 2. `.gitignore`
+- ✅ 已有 `*.key` 规则，`jwt_secret.key` 不会被提交
+
+### 3. 新增文档
+- ✅ `JWT_FIXES.md` - 详细的修复说明文档
+- ✅ `verify-jwt-fix.sh` - Bash 验证脚本
+- ✅ `verify-jwt-fix.ps1` - PowerShell 验证脚本
+
+---
+
+## 🎯 验证方法
+
+### 快速验证（PowerShell）
+```powershell
+.\verify-jwt-fix.ps1
+```
+
+### 手动验证步骤
+
+#### 1. 验证 JWT 密钥持久化
+```bash
+# 1. 启动服务
+./tg-imagebed.exe
+
+# 2. 检查日志输出
+# 应该看到：
+# [认证] 已生成并保存 JWT 密钥文件：jwt_secret.key
+
+# 3. 检查文件是否存在
+ls jwt_secret.key
+
+# 4. 登录获取 Token
+# 访问 http://localhost:8080/admin.html
+# 使用 API Key 登录，保存返回的 Token
+
+# 5. 重启服务
+# 停止并重新启动
+
+# 6. 检查日志
+# 应该看到：
+# [认证] 已加载 JWT 密钥文件：jwt_secret.key
+
+# 7. 验证之前的 Token
+# 使用之前保存的 Token 访问受保护的 API
+# 应该仍然有效
+```
+
+#### 2. 验证 `/admin.html` 访问
+```bash
+# 1. 直接在浏览器访问
+http://localhost:8080/admin.html
+
+# 2. 应该能够看到登录页面（不需要 Token）
+
+# 3. 输入 API Key 并登录
+
+# 4. 登录后应该能够访问管理界面
+```
+
+---
+
+## 🔒 安全考虑
+
+### JWT 密钥管理
+
+**当前实现**：
+- ✅ 密钥文件权限：0600（仅所有者可读写）
+- ✅ 文件位置：应用运行目录
+- ✅ 自动生成功能
+
+**生产环境建议**：
+1. **使用环境变量**：
+   ```go
+   secret := os.Getenv("JWT_SECRET")
+   if secret == "" {
+       // 回退到文件存储
+   }
+   ```
+
+2. **使用密钥管理服务**：
+   - AWS Secrets Manager
+   - HashiCorp Vault
+   - Azure Key Vault
+
+3. **定期轮换密钥**：
+   - 建议每月更换一次
+   - 轮换前通知用户重新登录
+
+4. **多实例部署**：
+   - 共享同一个密钥文件
+   - 使用集中式密钥管理服务
+
+---
+
+## 📊 影响评估
+
+### ✅ 正面影响
+
+1. **用户体验提升**：
+   - Token 在服务重启后仍然有效
+   - 避免意外登出
+   - 支持无缝的服务升级
+
+2. **运维便利性**：
+   - 支持多实例部署
+   - 减少认证相关的用户投诉
+   - 降低运维复杂度
+
+3. **系统稳定性**：
+   - 消除单点故障
+   - 提高服务可用性
+
+### ⚠️ 注意事项
+
+1. **升级影响**：
+   - 首次升级到新版本时，会生成新的密钥文件
+   - 所有用户的 Token 会失效，需要重新登录
+   - 建议在低峰期进行升级
+
+2. **文件管理**：
+   - 确保 `jwt_secret.key` 文件备份
+   - 删除该文件会导致所有 Token 失效
+   - 文件损坏会影响认证功能
+
+---
+
+## 🚀 部署清单
+
+### 全新部署
+- [ ] 确认代码已合并到主分支
+- [ ] 构建新版本二进制文件
+- [ ] 部署到服务器
+- [ ] 启动服务，检查日志
+- [ ] 验证 `jwt_secret.key` 文件生成
+- [ ] 测试登录功能
+- [ ] 验证 Token 持久性
+
+### 升级部署
+- [ ] 通知用户即将进行升级（Token 会失效）
+- [ ] 备份当前版本和配置
+- [ ] 停止旧版本服务
+- [ ] 更新代码/二进制文件
+- [ ] 启动新版本服务
+- [ ] 检查日志中的密钥加载信息
+- [ ] 验证登录功能正常
+- [ ] 监控用户反馈
+
+---
+
+## 📝 相关资源
+
+- [JWT 官方文档](https://jwt.io/)
+- [OWASP 认证指南](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
+- [详细修复说明](./JWT_FIXES.md)
+
+---
+
+## ✅ 完成状态
+
+- [x] 问题分析
+- [x] 代码修复
+- [x] 单元测试（通过编译验证）
+- [x] 文档编写
+- [x] 验证脚本
+- [x] 部署清单
+
+**修复完成时间**：2026-03-11  
+**修复人员**：AI Assistant
+
+---
+
+## <a id="file-12-quickstartmd"></a>QUICKSTART.md
+
+# 快速开始 - 5 分钟完成认证配置
+
+## 🚀 快速步骤（Windows）
+
+### 第 1 步：生成 API Key（30 秒）
+
+打开 PowerShell，运行：
+```powershell
+cd "d:\xiangmu\TG图床"
+.\generate-api-key.ps1
+```
+
+复制输出的 API Key，例如：
+```
+a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6
+```
+
+### 第 2 步：配置 data.json（1 分钟）
+
+编辑 `data.json` 文件，添加 api_keys 字段：
+
+```json
+{
+  "telegram": {
+    "bot_token": "你的 BOT_TOKEN",
+    "channel_id": "-1001234567890"
+  },
+  "mysql": {
+    "host": "localhost",
+    "port": 3306,
+    "username": "tg_imagebed",
+    "password": "你的密码",
+    "database": "tg_imagebed"
+  },
+  "admin": {
+    "user_ids": [你的用户 ID]
+  },
+  "api_keys": [
+    "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3x4y5z6"
+  ]
+}
+```
+
+**注意**: 将上面的示例 Key 替换为你生成的真实 Key。
+
+### 第 3 步：安装依赖（1 分钟）
+
+```bash
+cd "d:\xiangmu\TG图床"
+go mod tidy
+```
+
+如果提示找不到 go 命令，需要先安装 Go: https://golang.org/dl/
+
+### 第 4 步：重启服务（30 秒）
+
+```powershell
+.\stop.sh
+.\start.sh
+```
+
+或者如果使用 systemd（Linux）:
+```bash
+sudo systemctl restart telegram-bot-api
+```
+
+### 第 5 步：登录验证（1 分钟）
+
+1. 打开浏览器访问：`http://localhost:8080/admin.html`
+2. 输入配置的 API Key
+3. 点击"登录"按钮
+4. 成功进入管理后台 ✅
+
+## ⏱️ 总耗时：约 5 分钟
+
+## ❓ 遇到问题？
+
+### 问题 1: 找不到 generate-api-key.ps1
+
+**解决**: 手动生成一个随机字符串作为 API Key
+```powershell
+# PowerShell 生成随机 Key
+-join ((48..57) + (65..90) + (97..122) | Get-Random -Count 64 | ForEach-Object {[char]$_})
+```
+
+### 问题 2: 登录后提示 "API Key 无效"
+
+**检查**:
+1. data.json 中是否添加了 api_keys 字段
+2. API Key 是否与生成的一致（注意不要有多余空格）
+3. 服务是否已重启
+
+**示例配置**:
+```json
+{
+  "api_keys": ["你的-API-Key-这里"]
+}
+```
+
+### 问题 3: 无法访问 /admin.html
+
+**检查**:
+1. 服务是否正常启动
+2. 端口是否正确（默认 8080）
+3. Windows 防火墙设置
+
+### 问题 4: go mod tidy 失败
+
+**解决**:
+```bash
+# 手动添加 JWT 依赖
+go get github.com/golang-jwt/jwt/v5@v5.2.0
+
+# 然后再次尝试
+go mod tidy
+```
+
+## 📖 详细文档
+
+- 📘 完整配置指南：[AUTH_GUIDE.md](./AUTH_GUIDE.md)
+- ✅ 部署检查清单：[DEPLOYMENT_CHECKLIST.md](./DEPLOYMENT_CHECKLIST.md)
+- 🔄 升级说明：[UPGRADE_README.md](./UPGRADE_README.md)
+
+## 🎯 下一步
+
+登录成功后，你可以：
+
+1. 📊 查看统计数据（总文件数、今日上传等）
+2. 📁 管理文件列表（查看、删除）
+3. 🚫 封禁恶意 IP
+4. 🔍 搜索特定文件
+5. 📋 查看已封禁 IP 列表
+
+---
+
+**提示**: 生产环境建议使用 HTTPS 保护传输安全！
+
+---
+
+## <a id="file-13-readmemd"></a>README.md
+
+# TG图床
+
+基于Telegram 的文件上传服务，支持完整的后台管理系统。
+
+## ✨ 特性
+
+- 📤 **文件上传** - 上传文件到 Telegram 频道/群组
+- 🎨 **美观界面** - 现代化的 Web 上传界面
+- 🔐 **JWT 认证** - API Key + Token 双重认证机制（v2.0 新增）
+- 🔒 **后台管理** - 完整的管理后台系统
+- 📊 **数据统计** - 实时统计信息展示
+- 🚫 **IP 管理** - IP 封禁和解封功能
+- 💾 **数据库支持** - MySQL 数据库存储
+- 🔄 **多语言** - 支持 Go 和 Python 两种实现
+- 🚀 **高性能** - 本地缓存，快速响应
+
+## 📦 包含内容
+
+### Go版本（主要）
+- 完整的HTTP服务器
+- 后台管理系统
+- IP封禁功能
+- 统计信息API
+- 文件管理接口
+
+### Python版本
+- **bot/** - Telegram机器人版本
+- **bot2/** - Web服务器版本
+
+## 🚀 快速开始
+
+### 前置要求
+
+- Go 1.19+
+- MySQL 5.7+
+- Telegram Bot Token
+
+### 安装步骤
+
+1. **克隆仓库**
+```bash
+git clone https://github.com/YOUR_USERNAME/tg-imagebed.git
+cd tg-imagebed
+```
+
+2. **配置数据库**
+```bash
+# 复制配置文件模板
+cp data.json.example data.json
+
+# 编辑配置文件
+nano data.json
+```
+
+配置内容：
+```json
+{
+  "telegram": {
+    "bot_token": "YOUR_BOT_TOKEN",
+    "channel_id": "-1001234567890"
+  },
+  "mysql": {
+    "host": "localhost",
+    "port": 3306,
+    "username": "your_username",
+    "password": "your_password",
+    "database": "tg_imagebed"
+  },
+  "admin": {
+    "user_ids": [123456789]
+  }
+}
+```
+
+3. **初始化数据库**
+```bash
+bash init-db.sh
+```
+
+4. **生成 API Key**（v2.0 新增）
+```bash
+# Windows PowerShell
+.\generate-api-key.ps1
+
+# Linux/Mac
+./generate-api-key.sh
+```
+
+5. **配置 API Key**
+编辑 `data.json`，添加生成的 API Key：
+```json
+{
+  "telegram": {...},
+  "mysql": {...},
+  "admin": {...},
+  "api_keys": ["你的-API-Key-这里"]
+}
+```
+
+6. **编译程序**
+```bash
+go mod tidy
+go build -o tg-imagebed
+```
+
+7. **运行程序**
+```bash
+./tg-imagebed
+```
+
+### 访问服务
+
+- **上传界面**: http://localhost:8080/upload.html
+- **管理后台**: http://localhost:8080/admin.html
+- **认证方式**: API Key（从 data.json 配置）⚠️ v2.0 已升级，不再使用用户名密码
+
+### 📖 快速开始指南
+
+**5 分钟完成配置**: 查看 [QUICKSTART.md](./QUICKSTART.md)
+
+**详细配置指南**: 查看 [AUTH_GUIDE.md](./AUTH_GUIDE.md)
+
+**部署检查清单**: 查看 [DEPLOYMENT_CHECKLIST.md](./DEPLOYMENT_CHECKLIST.md)
+
+**升级说明**: 查看 [UPGRADE_README.md](./UPGRADE_README.md)
+
+## 📚 文档
+
+项目说明已统一合并到本 `README.md`，请优先参考下文的「统一说明」「更新日志」「保留数据迁移流程」章节。
+
+## 🌟 后台管理功能
+
+### 统计面板
+- 📊 总文件数
+- 📈 今日上传数
+- 👥 今日访问数
+- 🔒 封禁IP数量
+- 💾 缓存命中率
+
+### 文件管理
+- 📋 文件列表（分页显示）
+- 🔍 按IP搜索
+- 👁️ 在线预览
+- 🗑️ 删除文件
+- 🚫 封禁上传IP
+
+### IP管理
+- 🔐 封禁IP地址
+- ✅ 解封IP地址
+- 📋 查看封禁列表
+- 📝 封禁原因记录
+
+## 🔗 API接口
+
+### 统计信息
+```bash
+GET /api/stats
+Authorization: Basic base64(username:password)
+```
+
+### 文件列表
+```bash
+GET /api/files?page=1&ip=1.2.3.4
+Authorization: Basic base64(username:password)
+```
+
+### 封禁IP
+```bash
+POST /api/ban
+Authorization: Basic base64(username:password)
+Content-Type: application/json
+
+{
+  "ip": "1.2.3.4",
+  "reason": "恶意上传"
+}
+```
+
+详见 [admin/README.md](admin/README.md)
+
+## 🔐 安全建议
+
+1. ✅ **修改默认密码** - 编辑 `main.go` 中的 `adminUser/adminPass`
+2. 🔒 **使用HTTPS** - 配置Nginx反向代理
+3. 🛡️ **启用IP白名单** - 限制管理后台访问
+4. 💾 **定期备份** - 备份数据库和配置
+5. 📊 **监控日志** - 定期查看访问日志
+
+## 📁 项目结构
+
+```
+tg-imagebed/
+├── admin/                    # 后台管理前端
+│   ├── index.html           # 前端界面
+│   └── README.md            # 使用说明（后端逻辑已并入 main.go）
+├── bot/                     # Python Bot版本
+│   ├── bot.py
+│   ├── config.py
+│   └── requirements.txt
+├── bot2/                    # Python Server版本
+│   ├── server.py
+│   ├── server2.go
+│   └── requirements.txt
+├── main.go                  # Go主程序
+├── go.mod                   # Go模块配置
+├── data.json.example        # 配置文件模板
+├── init-db.sh               # 数据库初始化脚本
+├── build-with-admin.sh      # 编译脚本
+└── README.md                # 本文件
+```
+
+## 🛠️ 开发
+
+### 本地开发
+
+```bash
+# 安装依赖
+go mod download
+
+# 运行开发服务器
+go run main.go
+
+# 热重载（需要air）
+air
+```
+
+### 测试
+
+```bash
+# 测试API
+curl -u admin:password http://localhost:8080/api/stats
+
+# 测试上传
+curl -X POST -F "file=@test.jpg" http://localhost:8080/upload
+```
+
+## 🚀 部署
+
+### 使用Systemd
+
+```bash
+# 复制服务文件
+sudo cp telegram-bot-api.service /etc/systemd/system/
+
+# 启动服务
+sudo systemctl start tg-imagebed
+sudo systemctl enable tg-imagebed
+```
+
+### 使用Docker
+
+```bash
+# 构建镜像
+docker build -t tg-imagebed .
+
+# 运行容器
+docker run -d -p 8080:8080 tg-imagebed
+```
+
+部署说明已合并到本 README 的「统一说明（已合并）」章节
+
+## 📄 许可证
+
+MIT License
+
+## 🙏 致谢
+
+- [Telegram Bot API](https://core.telegram.org/bots/api)
+- [Go](https://go.dev/)
+- [MySQL](https://www.mysql.com/)
+
+## 📞 支持
+
+- 📧 提交Issue报告问题
+- 💬 查看文档获取帮助
+- 🌟 给项目点个Star
+
+---
+
+**注意**: 本项目仅供学习和个人使用，请勿用于非法用途。
+
+## 📘 统一说明（已合并）
+
+> 已将原先分散的部署、后台、反向代理、频道 ID 获取等说明整合到本 README，后续以本文件为主进行维护。
+
+### 后台管理快速使用
+
+1. 修改 `main.go` 中默认账号密码（务必修改）。
+2. 编译并启动服务：`go build -o tg-imagebed && ./tg-imagebed`。
+3. 访问后台：`http://localhost:8080/admin.html`。
+4. 常用接口：`/api/stats`、`/api/files`、`/api/ban`、`/api/unban`、`/api/delete`。
+
+### Debian 12 部署精简步骤
+
+```bash
+# 1) 安装依赖
+sudo apt update
+sudo apt install -y golang-go mysql-server nginx
+
+# 2) 初始化数据库（会保留已有数据）
+cp data.json.example data.json
+bash init-db.sh
+
+# 3) 编译并运行
+go build -o tg-imagebed
+./tg-imagebed
+```
+
+### 反向代理（Nginx 最小配置）
+
+``nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    client_max_body_size 20M;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_set_header EO-Client-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+
+### 统一管理脚本（推荐）
+
+已提供 `manage.sh` 统一管理以下操作：编译、启动、停止、重启、依赖安装、数据库初始化/迁移、运行状态检查、日志查看、数据包备份。
+
+```bash
+# 查看帮助
+bash manage.sh --help
+
+# 安装依赖
+bash manage.sh install-deps
+
+# 初始化/迁移数据库
+bash manage.sh init-db
+
+# 编译
+bash manage.sh build
+
+# 启动 / 停止 / 重启 / 状态
+bash manage.sh start
+bash manage.sh stop
+bash manage.sh restart
+bash manage.sh status
+
+# 查看日志（tail -f）
+bash manage.sh logs
+
+# 备份（配置 + 日志 + 可选数据库导出）
+bash manage.sh backup
+```
+
+### 获取 Telegram 频道 ID
+
+1. 将机器人加入目标频道并授予发送消息权限。
+2. 向频道发送一条测试消息。
+3. 使用 `https://api.telegram.org/bot<token>/getUpdates` 查看更新。
+4. 在返回 JSON 中找到 `chat.id`（一般为 `-100` 开头），填入 `data.json`。
+
+## 🧾 更新日志（主说明文件）
+
+- **2026-02-16**
+  - 新增：统一迁移 SQL `init_db.go.sql`，用于 Go 版本数据库初始化与兼容迁移。
+  - 优化：`init-db.sh` 改为使用 Python 解析 `data.json`，避免原正则解析 JSON 不稳定问题。
+  - 优化：`init-db.sh` 增加 SQL 文件存在性检查、关键字段校验与幂等迁移执行。
+  - 文档：将分散说明整合进主 README，并在此处持续记录新增功能与运维改动。
+  - 新增：`manage.sh` 统一管理脚本，整合启动/停止/重启/安装依赖/数据库初始化。
+  - 新增：`manage.sh backup` 数据包备份功能（配置、日志、可选数据库导出）。
+  - 修复：`init-db.sh` 始终读取脚本目录下的 `data.json`，避免跨目录执行误读配置。
+  - 兼容：迁移 SQL 中移除 `DEFAULT (CURRENT_TIMESTAMP + INTERVAL ...)`，适配 MySQL 5.7。
+  - 规范：继续统一 `.sh` 脚本 shebang / LF 行尾 / 入口行为。
+  - 规范：新增 `.gitattributes` 固定行尾策略，避免 CRLF 引发脚本问题。
+
+## 🛡️ 保留数据迁移流程
+
+> 目标：升级表结构时不丢失历史文件数据、访问统计和封禁记录。
+
+### 1) 迁移前检查
+
+```bash
+# 备份数据库（强烈建议）
+mysqldump -h<host> -P<port> -u<user> -p <database> > backup_before_migration.sql
+
+# 确认配置
+cp data.json.example data.json  # 如未创建
+nano data.json
+```
+
+### 2) 执行迁移（幂等）
+
+```bash
+bash init-db.sh
+```
+
+### 3) 迁移后验证
+
+```bash
+# 验证核心表是否存在
+mysql -h<host> -P<port> -u<user> -p <database> -e "SHOW TABLES LIKE 'files';"
+mysql -h<host> -P<port> -u<user> -p <database> -e "SHOW TABLES LIKE 'banned_ips';"
+
+# 验证新增字段
+mysql -h<host> -P<port> -u<user> -p <database> -e "SHOW COLUMNS FROM files LIKE 'file_name';"
+mysql -h<host> -P<port> -u<user> -p <database> -e "SHOW COLUMNS FROM files LIKE 'delete_reason';"
+```
+
+### 4) 回滚策略
+
+```bash
+# 若迁移后出现异常，可用备份恢复
+mysql -h<host> -P<port> -u<user> -p <database> < backup_before_migration.sql
+```
+
+---
+
+## <a id="file-14-reverse_proxymd"></a>REVERSE_PROXY.md
+
+# 文档已合并
+
+本文件内容已合并至项目主说明文档 `README.md`，请改为阅读：
+
+- `README.md` -> `统一说明（已合并）`
+- `README.md` -> `更新日志（主说明文件）`
+- `README.md` -> `保留数据迁移流程`
+
+---
+
+## <a id="file-15-upgrade_readmemd"></a>UPGRADE_README.md
+
+# 管理后台认证升级说明
+
+## 🎉 更新概览
+
+管理后台认证系统已完成全面升级，从原来的 **Basic Auth（用户名密码）** 迁移到 **API Key + JWT Token** 双重认证机制。
+
+## 📊 主要变化
+
+### 安全性提升
+
+✅ **更安全的凭据存储**
+- API Key 使用 SHA-256 哈希存储
+- 支持多个 API Key，便于团队管理
+- Token 有效期限制（2 小时），降低泄露风险
+
+✅ **更现代的认证流程**
+- JWT Token 自动过期机制
+- 前端无感 token 验证
+- 401 自动登出保护
+
+✅ **更好的用户体验**
+- 优雅的登录界面（替代浏览器弹窗）
+- 一键登出功能
+- 持久化登录状态（localStorage）
+
+### 技术架构
+
+**后端 (main.go)**:
+- ✅ 新增 JWT 库依赖：`github.com/golang-jwt/jwt/v5`
+- ✅ 实现 `/api/login` 接口：验证 API Key 并返回 token
+- ✅ 实现 `/api/verify` 接口：验证 token 有效性
+- ✅ JWT 认证中间件：替代旧的 Basic Auth 中间件
+- ✅ 配置结构扩展：支持 `api_keys` 数组
+
+**前端 (admin/index.html)**:
+- ✅ 独立登录页面 UI
+- ✅ Token 管理模块（localStorage）
+- ✅ 请求拦截器：自动附加 Authorization 头
+- ✅ 401 错误自动处理
+- ✅ 登出按钮和功能
+
+## 🔧 迁移指南
+
+### 对于新用户
+
+1. **生成 API Key**:
+   ```powershell
+   .\generate-api-key.ps1
+   ```
+
+2. **配置 data.json**:
+   ```json
+   {
+     "api_keys": ["你的-API-Key-这里"]
+   }
+   ```
+
+3. **重启服务并登录**:
+   - 访问 `/admin.html`
+   - 输入 API Key 登录
+
+### 对于老用户升级
+
+⚠️ **重要**: 旧的用户名密码认证已被移除，必须配置 API Key 才能访问管理后台。
+
+1. **备份当前配置**:
+   ```bash
+   cp data.json data.json.backup
+   ```
+
+2. **更新配置文件**:
+   在 `data.json` 中添加 `api_keys` 字段：
+   ```json
+   {
+     "telegram": {...},
+     "mysql": {...},
+     "admin": {...},
+     "api_keys": ["新生成的-API-Key"]
+   }
+   ```
+
+3. **更新代码**:
+   ```bash
+   git pull origin main
+   go mod tidy
+   ```
+
+4. **重启服务**:
+   ```bash
+   ./restart.sh
+   ```
+
+## 📁 新增文件
+
+```
+.
+├── generate-api-key.sh          # Linux/Mac API Key 生成脚本
+├── generate-api-key.ps1         # Windows API Key 生成脚本
+├── AUTH_GUIDE.md               # 详细认证配置指南
+├── DEPLOYMENT_CHECKLIST.md     # 部署检查清单
+└── UPGRADE_README.md           # 本文件
+```
+
+## 🔑 API Key 最佳实践
+
+### ✅ 推荐做法
+
+- 使用至少 32 字节的随机字符串
+- 定期更换（建议每 3-6 个月）
+- 为不同管理员配置不同的 Key
+- 生产环境务必使用 HTTPS
+
+### ❌ 避免做法
+
+- 不要使用示例中的默认 Key
+- 不要将 Key 提交到 Git
+- 不要在日志中暴露完整 Key
+- 不要在前端代码中硬编码 Key
+
+## 🛡️ 安全特性对比
+
+| 特性 | 旧版 (Basic Auth) | 新版 (JWT) |
+|------|------------------|-----------|
+| 凭据类型 | 明文密码 | API Key Hash |
+| 传输方式 | 每次请求携带密码 | Token（2 小时有效） |
+| 存储位置 | 代码硬编码 | 配置文件 |
+| 过期机制 | 无 | 自动过期 |
+| 多用户支持 | 单用户 | 多 Key 支持 |
+| 登出功能 | 无 | 支持 |
+| 暴力破解防护 | 弱 | 强（Hash 验证） |
+
+## 📈 性能影响
+
+- **Token 生成**: < 1ms
+- **Token 验证**: < 0.5ms
+- **内存占用**: 无明显变化
+- **并发支持**: 保持不变（50 连接池）
+
+## 🔍 故障排查
+
+### 常见问题
+
+**Q1: 无法登录，提示 "API Key 无效"**
+- 检查 data.json 是否配置 api_keys
+- 确认 Key 格式正确（无空格）
+- 重启服务
+
+**Q2: 登录后立即被退出**
+- 检查服务器时间是否准确
+- 清除浏览器缓存
+- 查看控制台 401 错误
+
+**Q3: 编译失败**
+```bash
+go mod tidy
+go get github.com/golang-jwt/jwt/v5@v5.2.0
+```
+
+## 📞 获取帮助
+
+- 📖 详细指南：[AUTH_GUIDE.md](./AUTH_GUIDE.md)
+- ✅ 部署检查：[DEPLOYMENT_CHECKLIST.md](./DEPLOYMENT_CHECKLIST.md)
+- 🔧 问题反馈：查看服务器日志
+
+## 🎯 后续计划
+
+- [ ] Token 刷新接口（无需重新登录续期）
+- [ ] 登录日志记录
+- [ ] Token 黑名单机制
+- [ ] 双因素认证 (2FA)
+- [ ] OAuth2 第三方登录
+
+---
+
+**升级日期**: 2026-03-11  
+**版本**: v2.0  
+**兼容性**: 需要 Go 1.19+
+
+---
+
+## <a id="file-16-admin-readmemd"></a>admin/README.md
+
+# 管理后台说明
+
+管理后台逻辑已合并到 `main.go`，包含：
+
+- `adminAuthMiddleware`
+- `/admin.html` 页面路由
+- `/api/stats`、`/api/files`、`/api/banned`、`/api/ban`、`/api/unban`、`/api/delete`
+
+默认账号密码在 `main.go` 中通过 `adminUser/adminPass` 配置。
+
+> 建议部署前务必修改默认密码。
+
+---
+
+## <a id="file-17-bot-readmemd"></a>bot/README.md
+
+# TG 图床 Bot 管理端
+
+独立的 Telegram Bot 管理模块，用于管理 TG 图床系统的文件、IP 封禁等。
+
+## 功能特性
+
+- 📋 文件管理：删除指定路径的文件
+- 🔒 IP 管理：封禁/解封 IP 地址，查看封禁列表
+- 📊 统计信息：查看系统统计数据
+- 🤖 Telegram Bot 集成：命令式交互
+
+## 目录结构
+
+```
+bot/
+├── __init__.py      # 模块初始化
+├── main.py          # Bot 主程序
+├── config.py        # 配置管理
+├── database.py      # 数据库操作
+├── handlers.py      # 命令处理器
+└── requirements.txt # Python 依赖
+```
+
+## 安装依赖
+
+```bash
+cd bot
+pip install -r requirements.txt
+```
+
+## 运行 Bot
+
+```bash
+python -m bot.main
+```
+
+或者直接运行：
+
+```bash
+python bot/main.py
+```
+
+## 命令列表
+
+| 命令 | 描述 | 示例 |
+|------|------|------|
+| `/start` | 显示帮助信息 | - |
+| `/delete <path>` | 删除文件 | `/delete abc123xyz` |
+| `/ban <ip> [reason]` | 封禁 IP | `/ban 192.168.1.1 恶意访问` |
+| `/unban <ip>` | 解封 IP | `/unban 192.168.1.1` |
+| `/list_bans` | 查看封禁列表 | - |
+| `/stats` | 查看统计信息 | - |
+
+## 配置文件
+
+Bot 使用项目根目录的 `data.json` 配置文件，需要包含以下配置：
+
+```json
+{
+  "telegram": {
+    "bot_token": "your_bot_token",
+    "channel_id": 1234567890
+  },
+  "mysql": {
+    "host": "localhost",
+    "port": 3306,
+    "username": "user",
+    "password": "password",
+    "database": "tgtc"
+  },
+  "admin": {
+    "user_ids": [123456789]
+  }
+}
+```
+
+## 注意事项
+
+- 所有管理命令需要管理员权限
+- IP 地址格式验证严格，仅支持有效的 IPv4/IPv6 地址
+- 日志文件为 `bot.log`
+
+---
+
+## <a id="file-18-bot2-readmemd"></a>bot2/README.md
+
+# Bot2 - TG 文件直链生成器
+
+## 功能说明
+
+Bot2 接收用户转发的文件，生成可访问的直链。具有以下特性：
+
+- 🔒 白名单权限管理，仅授权用户可生成直链
+- 📁 支持文档、图片、视频、音频、语音等所有文件类型
+- 🌐 自定义域名直链，格式与主项目一致
+- 💾 文件缓存机制，提高访问速度
+- 🛡️ IP 封禁功能，防止滥用
+
+## 系统架构
+
+```
+用户 → Bot (文件转发) → Bot2 (生成直链) → Database (存储)
+                                    ↓
+                               HTTP Server (提供访问)
+                                    ↓
+                            Telegram (文件存储)
+```
+
+## 安装步骤
+
+### 1. 数据库初始化
+
+```bash
+# 执行 SQL 脚本创建白名单表
+mysql -u root -p tgtc < init_db.sql
+```
+
+### 2. 创建 Bot Token
+
+1. 访问 [@BotFather](https://t.me/BotFather)
+2. 创建新 Bot：`/newbot`
+3. 记录生成的 Bot Token
+
+### 3. 配置文件
+
+复制配置模板：
+```bash
+cp data.json.example data.json
+```
+
+编辑 `data.json`：
+```json
+{
+  "telegram": {
+    "bot_token": "你的_BOT_TOKEN",
+    "bot_api_url": "http://127.0.0.1:8081"
+  },
+  "mysql": {
+    "host": "localhost",
+    "port": 3306,
+    "username": "tg_imagebed",
+    "password": "your_password",
+    "database": "tgtc"
+  },
+  "admin": {
+    "user_ids": [123456789]
+  },
+  "server": {
+    "listen_addr": ":8082",
+    "base_url": "https://your-domain.com"
+  }
+}
+```
+
+### 4. 安装依赖
+
+```bash
+# Bot 依赖
+pip install -r requirements.txt
+
+# HTTP Server 依赖
+pip install flask requests
+```
+
+### 5. 启动服务
+
+```bash
+# 启动 Bot（接收文件）
+python bot.py
+
+# 启动 HTTP Server（提供文件访问）
+python server.py
+```
+
+### 6. 使用 Systemd 管理（可选）
+
+创建服务文件 `/etc/systemd/system/bot2.service`：
+```ini
+[Unit]
+Description=Bot2 - TG File Link Generator
+After=network.target mysql.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/path/to/bot2
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+ExecStart=/usr/bin/python3 /path/to/bot2/bot.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+创建服务文件 `/etc/systemd/system/bot2-server.service`：
+```ini
+[Unit]
+Description=Bot2 HTTP Server
+After=network.target mysql.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/path/to/bot2
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+ExecStart=/usr/bin/python3 /path/to/bot2/server.py
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+启动服务：
+```bash
+systemctl daemon-reload
+systemctl start bot2 bot2-server
+systemctl enable bot2 bot2-server
+```
+
+## 使用方法
+
+### 生成直链
+
+1. 将 Bot 添加到白名单（需要管理员操作）
+2. 转发任意文件给 Bot
+3. Bot 返回可访问的直链
+
+### 管理命令
+
+| 命令 | 说明 | 权限 |
+|------|------|------|
+| `/start` | 显示帮助信息 | 所有用户 |
+| `/help` | 查看使用说明 | 所有用户 |
+| `/link` | 查看直链生成方法 | 所有用户 |
+| `/add <user_id>` | 添加用户到白名单 | 管理员 |
+| `/remove <user_id>` | 从白名单移除用户 | 管理员 |
+| `/list` | 查看白名单列表 | 管理员 |
+| `/stats` | 查看统计信息 | 管理员 |
+
+### API 接口
+
+#### 访问文件
+
+```
+GET https://your-domain.com/{random_path}
+```
+
+示例：
+```
+GET https://your-domain.com/abc123def456...
+```
+
+响应：
+- 成功：返回文件内容（支持在线预览）
+- 失败：返回 404 Not Found
+
+## 数据库结构
+
+### whitelist 表
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | INT | 主键 ID |
+| tg_user_id | BIGINT | Telegram 用户 ID（唯一） |
+| username | VARCHAR(255) | Telegram 用户名 |
+| added_by | BIGINT | 添加者用户 ID |
+| added_at | DATETIME | 添加时间 |
+| status | ENUM | 状态：active/removed |
+
+## 配置说明
+
+### telegram.bot_token
+Bot Token 从 @BotFather 获取
+
+### telegram.bot_api_url
+自建 Bot API 服务器地址，例如：`http://127.0.0.1:8081`
+
+### mysql
+数据库配置，与主项目共用同一个数据库
+
+### admin.user_ids
+管理员用户 ID 列表，只有管理员可以管理白名单
+
+### server.listen_addr
+HTTP 服务监听地址，例如：`:8082`
+
+### server.base_url
+访问域名，用于生成文件直链
+
+## 日志文件
+
+- `bot2.log`: Bot 运行日志
+- `bot2_server.log`: HTTP Server 运行日志
+
+## 故障排查
+
+### Bot 无法启动
+- 检查 `data.json` 配置是否正确
+- 确认数据库连接正常
+- 查看 `bot2.log` 日志
+
+### 文件无法访问
+- 检查 HTTP Server 是否运行
+- 确认缓存目录 `/data/cache` 有写入权限
+- 查看 `bot2_server.log` 日志
+
+### 权限不足
+- 确认用户 ID 在白名单中
+- 使用 `/list` 命令查看白名单
+
+## 安全建议
+
+1. 使用 Nginx 反向代理提供 HTTPS
+2. 限制 IP 白名单访问
+3. 定期检查日志文件
+4. 启用 IP 封禁功能防止滥用
+
+## 注意事项
+
+- Bot 和 HTTP Server 需要同时运行
+- 缓存目录 `/data/cache` 需要足够的磁盘空间
+- 直链格式与主项目保持一致
+- 自建 Bot API 必须使用 `--local` 模式


### PR DESCRIPTION
### Motivation
- 将仓库内分散的 Markdown 文档合并为一份便于检索和统一维护的文档快照，并对当前文档结构给出可优化建议。 
- 生成统一目录与锚点，方便查看每个原始文件的完整内容与相对位置。 
- 在合并结果中先行列出需要合并/精简或重构的文档分组与结构改进建议，以便后续整理文档目录。 

### Description
- 新增文件 `ALL_DOCS_MERGED.md`，其中包含仓库内全部 `.md` 文件的目录、锚点索引、可优化项检查结论，以及按文件逐条嵌入的原始内容。 
- 在合并文档开头加入了三项可优化建议：占位文档精简、主题重复统一和文档结构分层建议（例如建议新增 `docs/` 目录和导航矩阵）。 
- 使用一个短的 Python 生成流程遍历仓库 `.md` 文件并构建目录、锚点和合并内容（脚本在操作过程中用于生成 `ALL_DOCS_MERGED.md`）。 

### Testing
- 运行生成脚本并确认输出信息 `written 18 files` 表明已处理到全部目标文档，执行成功。 
- 使用 `wc -l ALL_DOCS_MERGED.md` 验证合并文件行数为 `2788`，确认内容已写入。 
- 使用 `sed -n '1,80p' ALL_DOCS_MERGED.md` 与 `nl -ba ALL_DOCS_MERGED.md | sed -n '1,120p'` 检查合并文件头部和前 120 行的目录与可优化项部分，输出符合预期。 
- 使用 `rg --files -g '*.md'` 列出源 Markdown 文件以验证参与合并的文件集合，命令执行成功。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1242b3fa483329a59a1737bce9b2b)