### PR TITLE
refactor(admin): simplify and modernize dashboard visuals

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -11,11 +11,31 @@
             box-sizing: border-box;
         }
 
+        :root {
+            --bg-page: #eef2f7;
+            --bg-panel: #ffffff;
+            --bg-soft: #f6f8fb;
+            --bg-muted: #eef2f6;
+            --text-primary: #1f2937;
+            --text-secondary: #4b5563;
+            --text-muted: #6b7280;
+            --border-color: #d6dde8;
+            --accent: #5f7895;
+            --accent-dark: #4d647d;
+            --danger: #b35e6b;
+            --danger-dark: #934c58;
+            --success: #4f8a77;
+            --success-dark: #3f6d5f;
+            --shadow-soft: 0 10px 24px rgba(15, 23, 42, 0.06);
+        }
+
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: var(--text-primary);
+            background: var(--bg-page);
             min-height: 100vh;
-            padding: 20px;
+            padding: 24px;
+            line-height: 1.55;
         }
 
         /* 登录页面样式 */
@@ -26,7 +46,7 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: rgba(238, 242, 247, 0.96);
             z-index: 2000;
             justify-content: center;
             align-items: center;
@@ -37,25 +57,26 @@
         }
 
         .login-box {
-            background: white;
-            border-radius: 16px;
-            padding: 40px;
+            background: var(--bg-panel);
+            border: 1px solid var(--border-color);
+            border-radius: 14px;
+            padding: 36px;
             max-width: 400px;
             width: 90%;
-            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.3);
+            box-shadow: var(--shadow-soft);
         }
 
         .login-title {
             font-size: 28px;
             font-weight: bold;
-            color: #333;
+            color: var(--text-primary);
             margin-bottom: 10px;
             text-align: center;
         }
 
         .login-subtitle {
             font-size: 14px;
-            color: #666;
+            color: var(--text-muted);
             margin-bottom: 30px;
             text-align: center;
         }
@@ -67,7 +88,7 @@
         .login-form input {
             width: 100%;
             padding: 14px;
-            border: 2px solid #e0e0e0;
+            border: 1px solid var(--border-color);
             border-radius: 8px;
             font-size: 16px;
             transition: border-color 0.3s;
@@ -75,13 +96,13 @@
 
         .login-form input:focus {
             outline: none;
-            border-color: #667eea;
+            border-color: var(--accent);
         }
 
         .login-btn {
             width: 100%;
             padding: 14px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: var(--accent);
             color: white;
             border: none;
             border-radius: 8px;
@@ -92,8 +113,7 @@
         }
 
         .login-btn:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+            background: var(--accent-dark);
         }
 
         .login-error {
@@ -116,15 +136,16 @@
         }
 
         .header {
-            background: rgba(255, 255, 255, 0.95);
-            border-radius: 16px;
-            padding: 30px;
-            margin-bottom: 20px;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+            background: var(--bg-panel);
+            border: 1px solid var(--border-color);
+            border-radius: 14px;
+            padding: 28px;
+            margin-bottom: 24px;
+            box-shadow: var(--shadow-soft);
         }
 
         .header h1 {
-            color: #333;
+            color: var(--text-primary);
             font-size: 28px;
             margin-bottom: 10px;
         }
@@ -137,8 +158,8 @@
 
         .btn-logout {
             padding: 10px 20px;
-            background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-            color: white;
+            background: #d9e2ec;
+            color: #2f4760;
             border: none;
             border-radius: 8px;
             font-size: 14px;
@@ -148,8 +169,7 @@
         }
 
         .btn-logout:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 15px rgba(245, 87, 108, 0.4);
+            background: #c5d3e1;
         }
 
         .stats-grid {
@@ -160,8 +180,9 @@
         }
 
         .stat-card {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
+            background: var(--bg-soft);
+            border: 1px solid var(--border-color);
+            color: var(--text-primary);
             padding: 20px;
             border-radius: 12px;
             text-align: center;
@@ -175,7 +196,7 @@
 
         .stat-label {
             font-size: 14px;
-            opacity: 0.9;
+            color: var(--text-muted);
         }
 
         .main-content {
@@ -185,19 +206,20 @@
         }
 
         .sidebar {
-            background: rgba(255, 255, 255, 0.95);
-            border-radius: 16px;
+            background: var(--bg-panel);
+            border: 1px solid var(--border-color);
+            border-radius: 14px;
             padding: 20px;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+            box-shadow: var(--shadow-soft);
             height: fit-content;
         }
 
         .sidebar h2 {
-            color: #333;
+            color: var(--text-primary);
             font-size: 20px;
             margin-bottom: 15px;
             padding-bottom: 10px;
-            border-bottom: 2px solid #667eea;
+            border-bottom: 1px solid var(--border-color);
         }
 
         .form-group {
@@ -206,7 +228,7 @@
 
         .form-group label {
             display: block;
-            color: #555;
+            color: var(--text-secondary);
             font-size: 14px;
             margin-bottom: 5px;
             font-weight: 500;
@@ -216,7 +238,7 @@
         .form-group textarea {
             width: 100%;
             padding: 12px;
-            border: 2px solid #e0e0e0;
+            border: 1px solid var(--border-color);
             border-radius: 8px;
             font-size: 14px;
             transition: border-color 0.3s;
@@ -225,7 +247,7 @@
         .form-group input:focus,
         .form-group textarea:focus {
             outline: none;
-            border-color: #667eea;
+            border-color: var(--accent);
         }
 
         .form-group textarea {
@@ -246,42 +268,39 @@
         }
 
         .btn-primary {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: var(--accent);
             color: white;
         }
 
         .btn-primary:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+            background: var(--accent-dark);
         }
 
         .btn-danger {
-            background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+            background: var(--danger);
             color: white;
         }
 
         .btn-danger:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 15px rgba(245, 87, 108, 0.4);
+            background: var(--danger-dark);
         }
 
         .btn-success {
-            background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+            background: var(--success);
             color: white;
         }
 
         .btn-success:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 15px rgba(79, 172, 254, 0.4);
+            background: var(--success-dark);
         }
 
         .btn-secondary {
-            background: #f0f0f0;
-            color: #333;
+            background: var(--bg-muted);
+            color: var(--text-secondary);
         }
 
         .btn-secondary:hover {
-            background: #e0e0e0;
+            background: #e4e9f0;
         }
 
         .banned-list {
@@ -291,8 +310,8 @@
         }
 
         .banned-item {
-            background: #fff5f5;
-            border-left: 4px solid #f5576c;
+            background: #faf5f6;
+            border-left: 3px solid var(--danger);
             padding: 12px;
             margin-bottom: 10px;
             border-radius: 4px;
@@ -300,55 +319,56 @@
 
         .banned-ip {
             font-weight: 600;
-            color: #f5576c;
+            color: var(--danger-dark);
             margin-bottom: 5px;
         }
 
         .banned-reason {
             font-size: 12px;
-            color: #666;
+            color: var(--text-muted);
             margin-bottom: 5px;
         }
 
         .banned-time {
             font-size: 11px;
-            color: #999;
+            color: #8b95a3;
         }
 
         .content-panel {
-            background: rgba(255, 255, 255, 0.95);
-            border-radius: 16px;
-            padding: 20px;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+            background: var(--bg-panel);
+            border: 1px solid var(--border-color);
+            border-radius: 14px;
+            padding: 24px;
+            box-shadow: var(--shadow-soft);
         }
 
         .tabs {
             display: flex;
             gap: 10px;
             margin-bottom: 20px;
-            border-bottom: 2px solid #e0e0e0;
+            border-bottom: 1px solid var(--border-color);
             padding-bottom: 10px;
         }
 
         .tab {
             padding: 10px 20px;
-            background: #f0f0f0;
+            background: var(--bg-muted);
             border: none;
             border-radius: 8px;
             cursor: pointer;
             font-size: 14px;
             font-weight: 600;
-            color: #666;
+            color: var(--text-secondary);
             transition: all 0.3s;
         }
 
         .tab.active {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            color: white;
+            background: #d9e4f0;
+            color: #2f4760;
         }
 
         .tab:hover:not(.active) {
-            background: #e0e0e0;
+            background: #e4e9f0;
         }
 
         .search-box {
@@ -360,19 +380,19 @@
         .search-box input {
             flex: 1;
             padding: 12px;
-            border: 2px solid #e0e0e0;
+            border: 1px solid var(--border-color);
             border-radius: 8px;
             font-size: 14px;
         }
 
         .search-box input:focus {
             outline: none;
-            border-color: #667eea;
+            border-color: var(--accent);
         }
 
         .search-box button {
             padding: 12px 24px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background: var(--accent);
             color: white;
             border: none;
             border-radius: 8px;
@@ -382,8 +402,7 @@
         }
 
         .search-box button:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 4px 15px rgba(102, 126, 234, 0.4);
+            background: var(--accent-dark);
         }
 
         .file-table {
@@ -396,30 +415,30 @@
         .file-table td {
             padding: 12px;
             text-align: left;
-            border-bottom: 1px solid #e0e0e0;
+            border-bottom: 1px solid #e7edf5;
         }
 
         .file-table th {
-            background: #f8f9fa;
-            color: #333;
+            background: var(--bg-soft);
+            color: var(--text-primary);
             font-weight: 600;
             position: sticky;
             top: 0;
         }
 
         .file-table tr:hover {
-            background: #f8f9fa;
+            background: #f8fafc;
         }
 
         .file-path {
             font-family: monospace;
-            color: #667eea;
+            color: var(--accent);
             font-size: 13px;
         }
 
         .file-info {
             font-size: 12px;
-            color: #666;
+            color: var(--text-muted);
         }
 
         .delete-reason {
@@ -432,8 +451,8 @@
         .ip-tag {
             display: inline-block;
             padding: 4px 8px;
-            background: #e3f2fd;
-            color: #1976d2;
+            background: #eaf0f6;
+            color: #406180;
             border-radius: 4px;
             font-size: 12px;
             font-family: monospace;
@@ -518,7 +537,7 @@
 
         .pagination button {
             padding: 8px 16px;
-            background: #f0f0f0;
+            background: var(--bg-muted);
             border: none;
             border-radius: 6px;
             cursor: pointer;
@@ -526,8 +545,8 @@
         }
 
         .pagination button:hover:not(:disabled) {
-            background: #667eea;
-            color: white;
+            background: #c8d6e5;
+            color: #2f4760;
         }
 
         .pagination button:disabled {
@@ -536,7 +555,7 @@
         }
 
         .pagination span {
-            color: #666;
+            color: var(--text-muted);
             font-size: 14px;
         }
 
@@ -600,7 +619,7 @@
             left: 0;
             width: 100%;
             height: 100%;
-            background: rgba(0, 0, 0, 0.5);
+            background: rgba(31, 41, 55, 0.35);
             z-index: 1000;
             justify-content: center;
             align-items: center;
@@ -612,18 +631,19 @@
 
         .modal-content {
             background: white;
-            border-radius: 16px;
+            border: 1px solid var(--border-color);
+            border-radius: 14px;
             padding: 30px;
             max-width: 500px;
             width: 90%;
-            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+            box-shadow: var(--shadow-soft);
         }
 
         .modal-header {
             font-size: 20px;
             font-weight: 600;
             margin-bottom: 20px;
-            color: #333;
+            color: var(--text-primary);
         }
 
         .modal-actions {


### PR DESCRIPTION
### Motivation
- 将管理后台视觉重构为更简约、现代且低饱和的风格以提升可读性与专业感，且不改变现有功能布局与响应式行为。 

### Description
- 在 `admin/index.html` 中新增可复用的主题 CSS 变量（`--bg-*`、`--text-*`、`--accent`、`--shadow-soft` 等）以统一低饱和灰蓝/浅灰调配色。  
- 将高饱和渐变与重阴影替换为扁平填充、细边框与轻柔阴影，并在头部、侧栏、统计卡、登录框、模态框、表格和按钮等核心组件上应用这些样式调整。  
- 优化全局排版与留白（例如 `padding`、`line-height`）以提升阅读体验。  
- 保持现有 HTML 结构、JS 逻辑与响应式断点（`1024px`、`768px`）不变，变更仅限表现层。 

### Testing
- 在项目根目录通过 `python -m http.server 4173 --bind 0.0.0.0` 启动本地静态服务器并确认页面可访问。  
- 使用 Playwright 打开 `http://127.0.0.1:4173/admin/index.html` 并保存截图为 `artifacts/admin-redesign.png` 以进行视觉回归检查。  
- 检查了生成的 CSS 差异以确认仅涉及视觉样式调整且未影响功能行为。  
- 上述自动化验证均已成功完成。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1354de454833280419d802cf6d571)