### PR TITLE
feat: 新增健康检查及管理端日志/封禁 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ go run ./cmd/server
 
 - `POST /api/auth/login`：登录
 - `POST /api/auth/refresh`：刷新 token
+- `GET /health`：健康检查
 
 ### 需登录
 
@@ -64,7 +65,11 @@ go run ./cmd/server
 
 ### 需 admin 或 super_admin
 
-- `GET /api/stats`：统计（当前为 TODO 占位返回）
+- `GET /api/stats`：统计
+- `GET /api/admin/logs`：操作日志分页（支持 `user_id`、`action` 过滤）
+- `GET /api/admin/bans`：封禁 IP 列表分页
+- `POST /api/admin/bans`：封禁 IP（JSON: `ip`, `reason`）
+- `DELETE /api/admin/bans?ip=<ip>`：解封 IP
 
 ## 5. 代码审查结论（截至 2026-04-24）
 
@@ -86,10 +91,10 @@ go run ./cmd/server
 
 | # | 建议 | 当前状态 |
 |---|------|----------|
-| 1 | 完善日志与封禁功能 | ⚠️ `internal/repository/log.go` 和 `ban.go` 仅为骨架，无实际 handler/service 调用 |
+| 1 | 完善日志与封禁功能 | ✅ 已补齐 `AdminService`、`AdminHandler` 并开放日志/封禁管理 API |
 | 2 | 文件上传 API | ⚠️ `config.json.example` 定义了 `upload` 配置，但项目中无上传处理器 |
 | 3 | 缓存管理 API | ⚠️ `config.json.example` 定义了 `cache` 配置，但无缓存清理/查询接口 |
-| 4 | 健康检查接口 | ⚠️ 缺失 `/health` 端点，K8s/负载均衡场景必需 |
+| 4 | 健康检查接口 | ✅ 已新增 `/health` 端点，返回服务状态与 UTC 时间 |
 | 5 | 访问统计 | ⚠️ `TodayAccess` 硬编码为 0，需在 files 表增加访问计数或新建访问日志表 |
 
 #### 二、工程质量类

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,7 +9,6 @@ import (
 	"syscall"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/jmoiron/sqlx"
 
 	"github.com/tg-imagebed-refactored/internal/config"
 	"github.com/tg-imagebed-refactored/internal/handler"
@@ -47,11 +46,13 @@ func main() {
 	authService := service.NewAuthService(userRepo, logRepo, &cfg.JWT)
 	userService := service.NewUserService(userRepo, logRepo)
 	statsService := service.NewStatsService(statsRepo)
+	adminService := service.NewAdminService(logRepo, banRepo)
 
 	// 初始化处理器
 	authHandler := handler.NewAuthHandler(authService)
 	userHandler := handler.NewUserHandler(userService)
 	statsHandler := handler.NewStatsHandler(statsService)
+	adminHandler := handler.NewAdminHandler(adminService)
 
 	// 初始化中间件
 	authMiddleware := middleware.NewAuthMiddleware(authService)
@@ -60,6 +61,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	// 公开接口
+	mux.HandleFunc("/health", handler.Health)
 	mux.HandleFunc("/api/auth/login", authHandler.Login)
 	mux.HandleFunc("/api/auth/refresh", authHandler.RefreshToken)
 
@@ -86,6 +88,19 @@ func main() {
 
 	// 管理员接口（需要admin或更高权限）
 	mux.HandleFunc("/api/stats", authRequired(authMiddleware.RequireAdmin(statsHandler.GetStats)))
+	mux.HandleFunc("/api/admin/logs", authRequired(authMiddleware.RequireAdmin(adminHandler.ListLogs)))
+	mux.HandleFunc("/api/admin/bans", authRequired(authMiddleware.RequireAdmin(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			adminHandler.ListBans(w, r)
+		case http.MethodPost:
+			adminHandler.BanIP(w, r)
+		case http.MethodDelete:
+			adminHandler.UnbanIP(w, r)
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})))
 
 	// 应用中间件
 	adminMux := applyMiddleware(mux)

--- a/internal/handler/admin.go
+++ b/internal/handler/admin.go
@@ -1,0 +1,156 @@
+package handler
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/tg-imagebed-refactored/internal/model"
+	"github.com/tg-imagebed-refactored/internal/service"
+	"github.com/tg-imagebed-refactored/pkg/response"
+)
+
+// AdminHandler 管理功能处理器（日志与封禁）
+type AdminHandler struct {
+	adminService service.AdminService
+}
+
+// NewAdminHandler 创建管理功能处理器
+func NewAdminHandler(adminService service.AdminService) *AdminHandler {
+	return &AdminHandler{adminService: adminService}
+}
+
+// ListLogs 获取操作日志
+func (h *AdminHandler) ListLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.BadRequest(w, "method not allowed")
+		return
+	}
+
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	pageSize, _ := strconv.Atoi(r.URL.Query().Get("page_size"))
+
+	var userID *int64
+	if q := strings.TrimSpace(r.URL.Query().Get("user_id")); q != "" {
+		parsed, err := strconv.ParseInt(q, 10, 64)
+		if err != nil {
+			response.BadRequest(w, "无效的user_id")
+			return
+		}
+		userID = &parsed
+	}
+
+	var action *string
+	if q := strings.TrimSpace(r.URL.Query().Get("action")); q != "" {
+		action = &q
+	}
+
+	logs, total, err := h.adminService.ListLogs(r.Context(), page, pageSize, userID, action)
+	if err != nil {
+		response.InternalError(w, "获取日志失败")
+		return
+	}
+
+	items := make([]*model.AdminLogResponse, len(logs))
+	for i, l := range logs {
+		items[i] = l.ToResponse()
+	}
+
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	response.Paginated(w, items, total, page, pageSize)
+}
+
+// ListBans 获取封禁列表
+func (h *AdminHandler) ListBans(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.BadRequest(w, "method not allowed")
+		return
+	}
+
+	page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+	pageSize, _ := strconv.Atoi(r.URL.Query().Get("page_size"))
+
+	bans, total, err := h.adminService.ListBans(r.Context(), page, pageSize)
+	if err != nil {
+		response.InternalError(w, "获取封禁列表失败")
+		return
+	}
+
+	items := make([]*model.BannedIPResponse, len(bans))
+	for i, ban := range bans {
+		items[i] = &model.BannedIPResponse{
+			IP:       net.IP(ban.IP).String(),
+			BannedAt: ban.BannedAt,
+			Reason:   ban.Reason,
+		}
+	}
+
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	response.Paginated(w, items, total, page, pageSize)
+}
+
+type banRequest struct {
+	IP     string `json:"ip"`
+	Reason string `json:"reason"`
+}
+
+// BanIP 封禁IP
+func (h *AdminHandler) BanIP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		response.BadRequest(w, "method not allowed")
+		return
+	}
+
+	var req banRequest
+	if err := decodeJSON(r, &req); err != nil {
+		response.BadRequest(w, "无效的请求格式")
+		return
+	}
+
+	if err := h.adminService.BanIP(r.Context(), req.IP, req.Reason); err != nil {
+		if err == service.ErrInvalidIP {
+			response.BadRequest(w, "无效的IP地址")
+			return
+		}
+		response.InternalError(w, "封禁IP失败")
+		return
+	}
+
+	response.SuccessMessage(w, "IP封禁成功")
+}
+
+// UnbanIP 解封IP
+func (h *AdminHandler) UnbanIP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		response.BadRequest(w, "method not allowed")
+		return
+	}
+
+	ip := strings.TrimSpace(r.URL.Query().Get("ip"))
+	if ip == "" {
+		response.BadRequest(w, "缺少ip参数")
+		return
+	}
+
+	if err := h.adminService.UnbanIP(r.Context(), ip); err != nil {
+		if err == service.ErrInvalidIP {
+			response.BadRequest(w, "无效的IP地址")
+			return
+		}
+		response.InternalError(w, "解封IP失败")
+		return
+	}
+
+	response.SuccessMessage(w, "IP解封成功")
+}

--- a/internal/handler/health.go
+++ b/internal/handler/health.go
@@ -1,0 +1,21 @@
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/tg-imagebed-refactored/pkg/response"
+)
+
+// Health 服务健康检查
+func Health(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		response.BadRequest(w, "method not allowed")
+		return
+	}
+
+	response.Success(w, map[string]interface{}{
+		"status": "ok",
+		"time":   time.Now().UTC().Format(time.RFC3339),
+	})
+}

--- a/internal/service/admin.go
+++ b/internal/service/admin.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+
+	"github.com/tg-imagebed-refactored/internal/model"
+	"github.com/tg-imagebed-refactored/internal/repository"
+)
+
+var (
+	ErrInvalidIP = errors.New("无效的IP地址")
+)
+
+// AdminService 管理功能服务（日志与封禁）
+type AdminService interface {
+	ListLogs(ctx context.Context, page, pageSize int, userID *int64, action *string) ([]*model.AdminLog, int64, error)
+	ListBans(ctx context.Context, page, pageSize int) ([]*model.BannedIP, int64, error)
+	BanIP(ctx context.Context, ip, reason string) error
+	UnbanIP(ctx context.Context, ip string) error
+}
+
+type adminService struct {
+	logRepo repository.AdminLogRepository
+	banRepo repository.BanRepository
+}
+
+// NewAdminService 创建管理功能服务
+func NewAdminService(logRepo repository.AdminLogRepository, banRepo repository.BanRepository) AdminService {
+	return &adminService{logRepo: logRepo, banRepo: banRepo}
+}
+
+func (s *adminService) ListLogs(ctx context.Context, page, pageSize int, userID *int64, action *string) ([]*model.AdminLog, int64, error) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
+
+	offset := (page - 1) * pageSize
+	logs, err := s.logRepo.List(ctx, offset, pageSize, userID, action)
+	if err != nil {
+		return nil, 0, err
+	}
+	total, err := s.logRepo.Count(ctx, userID, action)
+	if err != nil {
+		return nil, 0, err
+	}
+	return logs, total, nil
+}
+
+func (s *adminService) ListBans(ctx context.Context, page, pageSize int) ([]*model.BannedIP, int64, error) {
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 20
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
+
+	offset := (page - 1) * pageSize
+	bans, err := s.banRepo.List(ctx, offset, pageSize)
+	if err != nil {
+		return nil, 0, err
+	}
+	total, err := s.banRepo.Count(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	return bans, total, nil
+}
+
+func (s *adminService) BanIP(ctx context.Context, ip, reason string) error {
+	parsed := net.ParseIP(strings.TrimSpace(ip))
+	if parsed == nil {
+		return ErrInvalidIP
+	}
+	return s.banRepo.Ban(ctx, parsed, strings.TrimSpace(reason))
+}
+
+func (s *adminService) UnbanIP(ctx context.Context, ip string) error {
+	parsed := net.ParseIP(strings.TrimSpace(ip))
+	if parsed == nil {
+		return ErrInvalidIP
+	}
+	return s.banRepo.Unban(ctx, parsed)
+}

--- a/internal/service/auth.go
+++ b/internal/service/auth.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"errors"
 	"time"
@@ -16,8 +17,8 @@ import (
 
 var (
 	ErrInvalidCredentials = errors.New("用户名或密码错误")
-	ErrUserDisabled      = errors.New("账号已被禁用")
-	ErrUserNotFound      = errors.New("用户不存在")
+	ErrUserDisabled       = errors.New("账号已被禁用")
+	ErrUserNotFound       = errors.New("用户不存在")
 )
 
 // AuthService 认证服务接口
@@ -30,10 +31,10 @@ type AuthService interface {
 
 // AuthResult 认证结果
 type AuthResult struct {
-	AccessToken  string       `json:"access_token"`
-	RefreshToken string       `json:"refresh_token"`
-	ExpiresAt    time.Time    `json:"expires_at"`
-	User         *model.User  `json:"user"`
+	AccessToken  string      `json:"access_token"`
+	RefreshToken string      `json:"refresh_token"`
+	ExpiresAt    time.Time   `json:"expires_at"`
+	User         *model.User `json:"user"`
 }
 
 // Claims JWT Claims

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -44,6 +44,16 @@ func SuccessWithMessage(w http.ResponseWriter, message string, data interface{})
 	})
 }
 
+// SuccessMessage 返回成功响应（仅消息）
+func SuccessMessage(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(Response{
+		Success: true,
+		Message: message,
+	})
+}
+
 // Error 返回错误响应
 func Error(w http.ResponseWriter, statusCode int, message string) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")


### PR DESCRIPTION
### Motivation
- 完成 README 中未实现的功能项：提供健康检查端点与日志/封禁管理以满足运维与管理员需求。 
- 将已有的日志/封禁仓库骨架接入服务与 HTTP 层，便于后续前端或自动化运维调用。 

### Description
- 新增管理服务 `AdminService`（`internal/service/admin.go`）实现日志分页、封禁列表分页、封禁/解封 IP 的业务逻辑与参数校验。 
- 新增管理处理器 `AdminHandler`（`internal/handler/admin.go`）并提供 `GET /api/admin/logs`、`GET /api/admin/bans`、`POST /api/admin/bans`、`DELETE /api/admin/bans?ip=<ip>` 四个接口。 
- 新增健康检查处理器 `Health`（`internal/handler/health.go`）并注册 `GET /health` 路由；在 `cmd/server/main.go` 完成服务与路由接线。 
- 在统一响应包 `pkg/response/response.go` 补充 `SuccessMessage`，并修复 `internal/service/auth.go` 缺失 `database/sql` 导入；同时更新 `README.md` 中的 API 概要与待完善项状态。 

### Testing
- 格式化：已运行 `gofmt -w cmd/server/main.go internal/service/auth.go internal/service/admin.go internal/handler/admin.go internal/handler/health.go pkg/response/response.go`，执行成功。 
- 单元/集成测试：尝试运行 `go test ./...` 但失败，原因是环境无法从 `proxy.golang.org` 拉取依赖（返回 `Forbidden`），导致缺少 `go.sum` 条目并使测试无法完成。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebabd6e4dc8332803a1e0a23b1b180)