### PR TITLE
feat: 增强审计日志与访问日志管理

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - 设置公开/私有、访问次数限制、分享有效期（含过期检查）
 - 批量勾选图片一键生成 Markdown 链接
 - 后端代理下载（不暴露 Telegram 原始 URL），使用流式传输
-- 缩略图 RSA-OAEP 加密防外链，时间窗口 ±30 秒
+- 缩略图 RSA-OAEP 加密防外链，时间窗口 ±10 秒
 
 ### 分享访问
 - **公开无约束**：直接流式返回文件内容，CDN 友好
@@ -34,8 +34,8 @@
 - 文件管理、IP 封禁管理
 - 系统配置（SMTP、上传限制、认证开关），敏感配置仅限 SUPER_ADMIN
 - 文件类型过滤（黑名单/白名单双模式，危险类型带警告标识）
-- **访问统计**：请求量、带宽、独立访客、峰值 QPS 实时监控，趋势折线图 + 状态码分布饼图（ECharts），按时间范围筛选
-- **操作审计**：登录、配置变更、文件操作、权限修改等安全事件全量记录，支持按操作类型/用户/时间范围筛选
+- **访问统计**：请求量、带宽、独立访客、峰值 QPS 实时监控，趋势折线图 + 状态码分布饼图（ECharts 6），按时间范围筛选，支持 30s/1min/5min 自动刷新
+- **操作审计**：登录、配置变更、文件操作（含批量删除）、权限修改等安全事件全量记录，操作者自动关联用户名，支持按操作类型/用户/时间范围筛选，90 天自动清理
 
 ### 安全
 - Telegram Bot Token 错误日志自动脱敏
@@ -44,8 +44,9 @@
 - 配置缓存使用 upsert 原子操作
 - Source map 生产关闭、.gitignore 覆盖密钥文件
 - 前端全局错误边界防白屏
-- **操作审计系统**：异步记录所有关键安全事件（登录/登录失败/权限变更/文件操作/配置修改/IP 封禁），不影响主业务性能
-- **HTTP 访问日志**：全局中间件记录所有请求（IP/路径/状态码/耗时/带宽），数据持久化存储
+- **操作审计系统**：异步记录所有关键安全事件（登录/登录失败/权限变更/文件操作/配置修改/IP 封禁/批量删除），记录操作用户 ID，前端展示用户名
+- **HTTP 访问日志**：全局中间件记录所有请求（IP/路径/状态码/耗时/带宽），数据持久化存储，30 天自动清理
+- **审计日志**：90 天自动清理，防止数据库无限增长
 
 ## 技术栈
 
@@ -53,7 +54,7 @@
 |------|------|
 | 后端 | NestJS 10 + TypeScript (CommonJS, strict mode) + TypeORM 0.3 |
 | 数据库 | PostgreSQL ≥ 14 |
-| 前端 | Vue 3 + TypeScript + Vite 5 + TDesign + ECharts 5 |
+| 前端 | Vue 3 + TypeScript + Vite 5 + TDesign + ECharts 6 |
 | 存储 | Telegram Bot API（支持本地代理绕过限流） |
 | 邮件 | Nodemailer + SMTP |
 | 认证 | Passport JWT + bcryptjs |
@@ -125,6 +126,10 @@ CORS_ORIGINS=http://localhost:5173
 MAX_FILE_SIZE=20971520
 FILE_TYPE_MODE=blacklist      # blacklist 或 whitelist
 FILE_TYPE_FILTER=              # 逗号分隔的扩展名，如 .zip,.exe,.sh，空值不限制
+
+# 日志保留策略（定时自动清理）
+ACCESS_LOG_RETENTION_DAYS=30   # 访问日志保留天数
+AUDIT_LOG_RETENTION_DAYS=90    # 审计日志保留天数
 ```
 
 第一个注册的账号自动成为超级管理员。
@@ -137,19 +142,20 @@ FILE_TYPE_FILTER=              # 逗号分隔的扩展名，如 .zip,.exe,.sh，
 │   ├── app.module.ts         # 根模块（TypeORM、Schedule、事件发射器）
 │   ├── auth/                 # 登录/注册/邮箱验证/密码重置/状态查询
 │   ├── user/                 # 个人信息/密码修改/统计
-│   ├── file/                 # 上传/下载/分享/公开访问/缩略图加密
-│   ├── admin/                # 用户/文件/IP封禁/系统配置管理
+│   ├── file/                 # 上传/下载/分享/公开访问/缩略图加密/批量上传
+│   ├── admin/                # 用户/文件/IP封禁/系统配置管理（含批量删除审计）
 │   ├── telegram/             # Telegram Bot API 上传下载（流式传输，Token 脱敏）
 │   ├── mailer/               # SMTP 邮件（事件驱动配置热更新）
 │   ├── config/               # 动态配置缓存
-│   ├── tasks/                # 定时清理（过期限流/Token/封禁）
+│   ├── tasks/                # 定时清理（限流/Token/封禁/访问日志/审计日志）
 │   ├── common/
 │   │   ├── entities/         # 10 个数据实体（含 AuditLog, AccessLog）
 │   │   ├── services/         # ConfigCacheService + RateLimitService + AuditService
 │   │   ├── guards/           # JWT 认证 + 角色权限守卫
 │   │   ├── decorators/       # @CurrentUser @Roles
 │   │   ├── interceptors/     # 统一响应 { code, message, data }
-│   │   └── middleware/       # AccessLogMiddleware（全局 HTTP 请求日志）
+│   │   ├── middleware/       # AccessLogMiddleware（全局 HTTP 请求日志，追踪实际发送字节数）
+│   │   ├── utils/            # client-ip.ts crypto.util.ts
 │   ├── database/             # TypeORM CLI DataSource（含 dotenv/config 加载）
 │   └── migrations/           # 9 个数据库迁移文件
 │
@@ -162,9 +168,9 @@ FILE_TYPE_FILTER=              # 逗号分隔的扩展名，如 .zip,.exe,.sh，
 │   ├── components/           # UploadModal ThumbnailImg
 │   ├── stores/               # auth files (Pinia)
 │   ├── router/               # 四级路由守卫链 + redirect 安全校验
-│   ├── api/                  # axios 客户端（30s 超时，401 防抖）
+│   ├── api/                  # axios 客户端（10s 超时，401 防抖）
 │   ├── types/                # TS 类型定义
-│   └── utils/                # error.ts thumbnail.ts
+│   └── utils/                # error.ts format.ts thumbnail.ts
 │
 ├── .gitignore
 ├── LICENSE
@@ -238,7 +244,7 @@ npm run typecheck            # TypeScript 类型检查
 | GET | `/api/admin/access-logs` | HTTP 访问日志（分页/筛选） |
 | GET | `/api/admin/access-logs/stats` | 访问统计（请求量/带宽/UV/QPS） |
 | GET | `/api/admin/access-logs/trend` | 流量趋势时序数据 |
-| GET | `/api/admin/audit-logs` | 操作审计日志（分页/筛选） |
+| GET | `/api/admin/audit-logs` | 操作审计日志（分页/筛选，含关联用户名） |
 
 ## 许可证
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -58,3 +58,11 @@ MAX_FILE_SIZE=20971520
 # FILE_TYPE_MODE=blacklist
 # 文件类型过滤列表，逗号分隔的扩展名，如 .zip,.exe,.sh。空值 = 不限制
 # FILE_TYPE_FILTER=
+
+# ==========================================
+# 日志保留策略
+# ==========================================
+# 访问日志保留天数（默认 30 天）
+ACCESS_LOG_RETENTION_DAYS=30
+# 审计日志保留天数（默认 90 天）
+AUDIT_LOG_RETENTION_DAYS=90

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -32,18 +32,20 @@ export class AdminController {
   @Put('config')
   @Roles(UserRole.SUPER_ADMIN)
   async updateConfig(
+    @CurrentUser() user: User,
     @Body() dto: ConfigDto,
   ) {
-    await this.adminService.updateConfig(dto.key, dto.value, dto.description);
+    await this.adminService.updateConfig(user, dto.key, dto.value, dto.description);
     return { message: '配置已更新' };
   }
 
   @Put('config/batch')
   @Roles(UserRole.SUPER_ADMIN)
   async updateConfigs(
+    @CurrentUser() user: User,
     @Body() dto: BatchConfigDto,
   ) {
-    await this.adminService.updateConfigs(dto.configs);
+    await this.adminService.updateConfigs(user, dto.configs);
     return { message: '配置已批量更新' };
   }
 
@@ -55,9 +57,11 @@ export class AdminController {
 
   @Post('banned-ips')
   async banIP(
+    @CurrentUser() user: User,
     @Body() dto: BanIPDto,
   ) {
     await this.adminService.banIP(
+      user,
       dto.ip,
       dto.reason,
       dto.permanent !== false,
@@ -67,15 +71,21 @@ export class AdminController {
   }
 
   @Delete('banned-ips/:ip')
-  async unbanIP(@Param('ip') ip: string) {
-    await this.adminService.unbanIP(ip);
+  async unbanIP(
+    @CurrentUser() user: User,
+    @Param('ip') ip: string,
+  ) {
+    await this.adminService.unbanIP(user, ip);
     return { message: 'IP已解封' };
   }
 
   // 推荐方式：通过请求体传递 IP，避免 IPv6 冒号导致 URL 解析问题
   @Post('banned-ips/unban')
-  async unbanIPByBody(@Body() dto: UnbanIPDto) {
-    await this.adminService.unbanIP(dto.ip);
+  async unbanIPByBody(
+    @CurrentUser() user: User,
+    @Body() dto: UnbanIPDto,
+  ) {
+    await this.adminService.unbanIP(user, dto.ip);
     return { message: 'IP已解封' };
   }
 
@@ -90,15 +100,21 @@ export class AdminController {
 
   @Delete('files/:id')
   @Roles(UserRole.SUPER_ADMIN)
-  async deleteFile(@Param('id') id: string) {
-    await this.adminService.deleteFile(id);
+  async deleteFile(
+    @CurrentUser() user: User,
+    @Param('id') id: string,
+  ) {
+    await this.adminService.deleteFile(user, id);
     return { message: '文件已删除' };
   }
 
   @Post('files/batch-delete')
   @Roles(UserRole.SUPER_ADMIN)
-  async batchDeleteFiles(@Body() dto: BatchDeleteFilesDto) {
-    await this.adminService.batchDeleteFiles(dto.ids);
+  async batchDeleteFiles(
+    @CurrentUser() user: User,
+    @Body() dto: BatchDeleteFilesDto,
+  ) {
+    await this.adminService.batchDeleteFiles(user, dto.ids);
     return { message: '文件已批量删除' };
   }
 
@@ -110,8 +126,11 @@ export class AdminController {
 
   @Put('smtp')
   @Roles(UserRole.SUPER_ADMIN)
-  async updateSMTPConfig(@Body() dto: SmtpConfigDto) {
-    await this.adminService.updateSMTPConfig(dto);
+  async updateSMTPConfig(
+    @CurrentUser() user: User,
+    @Body() dto: SmtpConfigDto,
+  ) {
+    await this.adminService.updateSMTPConfig(user, dto);
     return { message: 'SMTP配置已更新' };
   }
 
@@ -123,8 +142,11 @@ export class AdminController {
 
   @Put('upload-config')
   @Roles(UserRole.SUPER_ADMIN)
-  async updateUploadConfig(@Body() dto: UploadConfigDto) {
-    await this.adminService.updateUploadConfig(dto);
+  async updateUploadConfig(
+    @CurrentUser() user: User,
+    @Body() dto: UploadConfigDto,
+  ) {
+    await this.adminService.updateUploadConfig(user, dto);
     return { message: '上传配置已更新' };
   }
 
@@ -136,8 +158,11 @@ export class AdminController {
 
   @Put('auth-config')
   @Roles(UserRole.SUPER_ADMIN)
-  async updateAuthConfig(@Body() dto: AuthConfigDto) {
-    await this.adminService.updateAuthConfig(dto);
+  async updateAuthConfig(
+    @CurrentUser() user: User,
+    @Body() dto: AuthConfigDto,
+  ) {
+    await this.adminService.updateAuthConfig(user, dto);
     return { message: '认证配置已更新' };
   }
 

--- a/backend/src/admin/admin.service.ts
+++ b/backend/src/admin/admin.service.ts
@@ -127,20 +127,35 @@ export class AdminService {
     return this.configCacheService.get(key, '');
   }
 
-  async updateConfig(key: string, value: string, description?: string): Promise<void> {
-    await this.configCacheService.set(key, value, description);
+  async updateConfig(user: User, key: string, value: string, description?: string): Promise<void> {
+    await this.setConfigValue(key, value, description);
 
     // 审计日志：配置变更
     this.auditService.log({
       action: 'config_change',
+      userId: user.id,
       resourceType: 'config',
       resourceId: key,
       metadata: { value: value.substring(0, 100), description },
     });
   }
 
-  async updateConfigs(configs: { key: string; value: string; description?: string }[]): Promise<void> {
+  /** 仅写入配置不记录审计（供批量操作内部调用，避免重复记录） */
+  private async setConfigValue(key: string, value: string, description?: string): Promise<void> {
+    await this.configCacheService.set(key, value, description);
+  }
+
+  async updateConfigs(user: User, configs: { key: string; value: string; description?: string }[]): Promise<void> {
     await this.configCacheService.setBatch(configs);
+
+    // 审计日志：批量配置变更
+    this.auditService.log({
+      action: 'config_change',
+      userId: user.id,
+      resourceType: 'config',
+      resourceId: 'batch',
+      metadata: { keys: configs.map(c => c.key) },
+    });
   }
 
   async getBannedIPs(): Promise<BannedIP[]> {
@@ -149,9 +164,9 @@ export class AdminService {
     });
   }
 
-  async banIP(ip: string, reason?: string, permanent = true, expiresAt?: Date): Promise<void> {
+  async banIP(user: User, ip: string, reason?: string, permanent = true, expiresAt?: Date): Promise<void> {
     const existing = await this.bannedIPRepository.findOne({ where: { ip } });
-    
+
     if (existing) {
       throw new BadRequestException('该IP已被封禁');
     }
@@ -167,15 +182,16 @@ export class AdminService {
     // 审计日志：IP 封禁
     this.auditService.log({
       action: 'ip_ban',
+      userId: user.id,
       resourceType: 'ip',
       resourceId: ip,
       metadata: { reason, permanent },
     });
   }
 
-  async unbanIP(ip: string): Promise<void> {
+  async unbanIP(user: User, ip: string): Promise<void> {
     const bannedIP = await this.bannedIPRepository.findOne({ where: { ip } });
-    
+
     if (!bannedIP) {
       throw new NotFoundException('该IP未被封禁');
     }
@@ -185,6 +201,7 @@ export class AdminService {
     // 审计日志：IP 解封
     this.auditService.log({
       action: 'ip_unban',
+      userId: user.id,
       resourceType: 'ip',
       resourceId: ip,
     });
@@ -201,9 +218,9 @@ export class AdminService {
     return this.fileService.findAll(page, limit);
   }
 
-  async deleteFile(id: string): Promise<void> {
+  async deleteFile(user: User, id: string): Promise<void> {
     const file = await this.fileRepository.findOne({ where: { id } });
-    
+
     if (!file) {
       throw new NotFoundException('文件不存在');
     }
@@ -214,18 +231,20 @@ export class AdminService {
     // 审计日志：管理员删除文件
     this.auditService.log({
       action: 'file_delete',
+      userId: user.id,
       resourceType: 'file',
       resourceId: id,
       metadata: { filename: file.originalName },
     });
   }
 
-  async batchDeleteFiles(ids: string[]): Promise<void> {
+  async batchDeleteFiles(user: User, ids: string[]): Promise<void> {
     await this.fileRepository.update(ids, { isDeleted: true });
 
     // 审计日志：批量删除文件
     this.auditService.log({
       action: 'batch_delete_files',
+      userId: user.id,
       resourceType: 'file',
       metadata: { count: ids.length, ids },
     });
@@ -246,20 +265,21 @@ export class AdminService {
     };
   }
 
-  async updateAuthConfig(config: {
+  async updateAuthConfig(user: User, config: {
     registrationEnabled?: boolean;
     emailVerificationEnabled?: boolean;
   }): Promise<void> {
     if (config.registrationEnabled !== undefined) {
-      await this.updateConfig('REGISTRATION_ENABLED', config.registrationEnabled.toString(), '是否允许新用户注册');
+      await this.setConfigValue('REGISTRATION_ENABLED', config.registrationEnabled.toString(), '是否允许新用户注册');
     }
     if (config.emailVerificationEnabled !== undefined) {
-      await this.updateConfig('EMAIL_VERIFICATION_ENABLED', config.emailVerificationEnabled.toString(), '是否开启邮箱验证码');
+      await this.setConfigValue('EMAIL_VERIFICATION_ENABLED', config.emailVerificationEnabled.toString(), '是否开启邮箱验证码');
     }
 
     // 审计日志：认证配置变更
     this.auditService.log({
       action: 'auth_config_change',
+      userId: user.id,
       resourceType: 'config',
       resourceId: 'auth',
       metadata: config,
@@ -290,7 +310,7 @@ export class AdminService {
     };
   }
 
-  async updateSMTPConfig(config: {
+  async updateSMTPConfig(user: User, config: {
     host: string;
     port: number;
     secure: boolean;
@@ -298,7 +318,7 @@ export class AdminService {
     password: string;
     from: string;
   }): Promise<void> {
-    await this.updateConfigs([
+    await this.configCacheService.setBatch([
       { key: 'SMTP_HOST', value: config.host, description: 'SMTP服务器地址' },
       { key: 'SMTP_PORT', value: config.port.toString(), description: 'SMTP服务器端口' },
       { key: 'SMTP_SECURE', value: config.secure.toString(), description: '是否使用SSL' },
@@ -310,6 +330,7 @@ export class AdminService {
     // 审计日志：SMTP 配置变更
     this.auditService.log({
       action: 'smtp_config_change',
+      userId: user.id,
       resourceType: 'config',
       resourceId: 'smtp',
     });
@@ -333,26 +354,27 @@ export class AdminService {
     };
   }
 
-  async updateUploadConfig(config: {
+  async updateUploadConfig(user: User, config: {
     maxFileSize?: number;
     fileTypeMode?: string;
     fileTypeFilter?: string;
   }): Promise<void> {
     if (config.maxFileSize !== undefined) {
-      await this.updateConfig('MAX_FILE_SIZE', config.maxFileSize.toString(), '最大文件大小（字节）');
+      await this.setConfigValue('MAX_FILE_SIZE', config.maxFileSize.toString(), '最大文件大小（字节）');
     }
 
     if (config.fileTypeMode !== undefined) {
-      await this.updateConfig('FILE_TYPE_MODE', config.fileTypeMode, '文件类型过滤模式（blacklist/whitelist）');
+      await this.setConfigValue('FILE_TYPE_MODE', config.fileTypeMode, '文件类型过滤模式（blacklist/whitelist）');
     }
 
     if (config.fileTypeFilter !== undefined) {
-      await this.updateConfig('FILE_TYPE_FILTER', config.fileTypeFilter, '文件类型过滤列表（逗号分隔）');
+      await this.setConfigValue('FILE_TYPE_FILTER', config.fileTypeFilter, '文件类型过滤列表（逗号分隔）');
     }
 
     // 审计日志：上传配置变更
     this.auditService.log({
       action: 'upload_config_change',
+      userId: user.id,
       resourceType: 'config',
       resourceId: 'upload',
       metadata: config,
@@ -524,31 +546,54 @@ export class AdminService {
     action?: string;
     userId?: string;
     timeRange?: string;
-  }): Promise<{ items: AuditLog[]; total: number }> {
+  }): Promise<{ items: (AuditLog & { username?: string })[]; total: number }> {
     const page = Math.max(1, query.page || 1);
     const limit = Math.min(100, Math.max(1, query.limit || 20));
     const since = this.parseTimeRange(query.timeRange || '24h');
 
-    const qb = this.auditLogRepo
+    // 基础条件查询（供 count 和 items 共用）
+    const baseQb = this.auditLogRepo
       .createQueryBuilder('log')
       .where('log.createdAt >= :since', { since });
 
     if (query.action) {
-      qb.andWhere('log.action = :action', { action: query.action });
+      baseQb.andWhere('log.action = :action', { action: query.action });
     }
 
     if (query.userId) {
-      qb.andWhere('log.userId = :userId', { userId: query.userId });
+      baseQb.andWhere('log.userId = :userId', { userId: query.userId });
     }
 
-    const total = await qb.getCount();
+    const total = await baseQb.getCount();
 
-    const items = await qb
+    // 带用户名联查的数据查询
+    const items = await baseQb
+      .leftJoin(User, 'u', 'CAST(u.id AS varchar) = log.userId')
+      .select([
+        'log.id', 'log.userId', 'log.action', 'log.ip',
+        'log.resourceType', 'log.resourceId', 'log.metadata',
+        'log.status', 'log.createdAt',
+      ])
+      .addSelect('u.email', 'username')
       .orderBy('log.createdAt', 'DESC')
       .skip((page - 1) * limit)
       .take(limit)
-      .getMany();
+      .getRawMany();
 
-    return { items, total };
+    return {
+      items: items.map(item => ({
+        id: item.log_id,
+        userId: item.log_userId,
+        username: item.username || null,
+        action: item.log_action,
+        ip: item.log_ip,
+        resourceType: item.log_resourceType,
+        resourceId: item.log_resourceId,
+        metadata: item.log_metadata,
+        status: item.log_status,
+        createdAt: item.log_createdAt,
+      })),
+      total,
+    };
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -78,8 +78,9 @@ export class AuthService {
       // 锁定 users 表防止并发注册竞态，确保首个注册用户获得 super_admin
       // 使用 FOR UPDATE 确保在 REPEATABLE READ 下也能读到最新数据
       await queryRunner.query('LOCK TABLE "users" IN EXCLUSIVE MODE');
+      // 表已通过 LOCK TABLE 锁定，无需 FOR UPDATE（PostgreSQL 不允许对聚合函数使用 FOR UPDATE）
       const [{ count }] = await queryRunner.query(
-        'SELECT COUNT(*) as count FROM "users" FOR UPDATE',
+        'SELECT COUNT(*) as count FROM "users"',
       );
       const role = Number(count) === 0 ? UserRole.SUPER_ADMIN : UserRole.USER;
 

--- a/backend/src/common/entities/access-log.entity.ts
+++ b/backend/src/common/entities/access-log.entity.ts
@@ -1,6 +1,6 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   Index,
@@ -8,7 +8,7 @@ import {
 
 @Entity('access_logs')
 export class AccessLog {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;
 
   @Index()

--- a/backend/src/common/entities/audit-log.entity.ts
+++ b/backend/src/common/entities/audit-log.entity.ts
@@ -1,6 +1,6 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
 } from 'typeorm';
@@ -43,7 +43,7 @@ export enum AuditStatus {
 
 @Entity('audit_logs')
 export class AuditLog {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;
 
   @Column({ nullable: true, comment: '操作者ID，匿名操作可为空' })

--- a/backend/src/common/entities/banned-ip.entity.ts
+++ b/backend/src/common/entities/banned-ip.entity.ts
@@ -1,13 +1,13 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
 } from 'typeorm';
 
 @Entity('banned_ips')
 export class BannedIP {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;
 
   @Column({ unique: true })

--- a/backend/src/common/entities/file-access-log.entity.ts
+++ b/backend/src/common/entities/file-access-log.entity.ts
@@ -1,6 +1,6 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   ManyToOne,
@@ -16,7 +16,7 @@ export enum AccessAction {
 
 @Entity('file_access_logs')
 export class FileAccessLog {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;
 
   @ManyToOne(() => File)

--- a/backend/src/common/entities/file.entity.ts
+++ b/backend/src/common/entities/file.entity.ts
@@ -1,6 +1,6 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -16,7 +16,7 @@ export enum FileAccessType {
 
 @Entity('files')
 export class File {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;
 
   @Column()

--- a/backend/src/common/entities/rate-limit.entity.ts
+++ b/backend/src/common/entities/rate-limit.entity.ts
@@ -1,6 +1,6 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -8,7 +8,7 @@ import {
 
 @Entity('rate_limits')
 export class RateLimit {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;
 
   @Column({ unique: true })

--- a/backend/src/common/entities/share-audit.entity.ts
+++ b/backend/src/common/entities/share-audit.entity.ts
@@ -1,6 +1,6 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
 } from 'typeorm';
@@ -9,7 +9,7 @@ export type ShareAuditAction = 'create' | 'revoke' | 'access' | 'consume';
 
 @Entity('share_audits')
 export class ShareAudit {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;
 
   @Column({ unique: true })

--- a/backend/src/common/entities/system-config.entity.ts
+++ b/backend/src/common/entities/system-config.entity.ts
@@ -1,13 +1,13 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
   Column,
   UpdateDateColumn,
 } from 'typeorm';
 
 @Entity('system_configs')
 export class SystemConfig {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;
 
   @Column({ unique: true })

--- a/backend/src/common/entities/user.entity.ts
+++ b/backend/src/common/entities/user.entity.ts
@@ -1,6 +1,6 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
@@ -16,7 +16,7 @@ export enum UserRole {
 
 @Entity('users')
 export class User {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;
 
   @Column({ unique: true })

--- a/backend/src/common/entities/verification-code.entity.ts
+++ b/backend/src/common/entities/verification-code.entity.ts
@@ -1,13 +1,13 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
   Column,
   CreateDateColumn,
 } from 'typeorm';
 
 @Entity('verification_codes')
 export class VerificationCode {
-  @PrimaryGeneratedColumn('uuid')
+  @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;
 
   @Column()

--- a/backend/src/common/middleware/access-log.middleware.ts
+++ b/backend/src/common/middleware/access-log.middleware.ts
@@ -25,9 +25,31 @@ export class AccessLogMiddleware implements NestMiddleware {
       return;
     }
 
+    // 通过拦截 write/end 追踪实际发送的字节数（兼容流式响应和 gzip 压缩）
+    let bytesSent = 0;
+    const originalWrite = res.write.bind(res) as typeof res.write;
+    const originalEnd = res.end.bind(res) as typeof res.end;
+    const self = this;
+
+    res.write = function (chunk: unknown, ...rest: any[]): boolean {
+      if (typeof chunk === 'string' || Buffer.isBuffer(chunk)) {
+        const data = chunk as string | Buffer;
+        bytesSent += Buffer.isBuffer(data) ? data.length : Buffer.byteLength(data);
+      }
+      return (originalWrite as any)(chunk, ...rest);
+    };
+
+    res.end = function (chunk: unknown, ...rest: any[]): any {
+      if (typeof chunk === 'string' || Buffer.isBuffer(chunk)) {
+        const data = chunk as string | Buffer;
+        bytesSent += Buffer.isBuffer(data) ? data.length : Buffer.byteLength(data);
+      }
+      return (originalEnd as any)(chunk, ...rest);
+    };
+
     // 在响应完成时记录日志
     res.on('finish', () => {
-      this.logAsync(req, res, Date.now() - start, path).catch(() => {
+      self.logAsync(req, res, Date.now() - start, path, bytesSent).catch(() => {
         // 日志写入失败不影响业务
       });
     });
@@ -40,10 +62,16 @@ export class AccessLogMiddleware implements NestMiddleware {
     res: Response,
     duration: number,
     path: string,
+    bytesSent: number,
   ): Promise<void> {
     try {
       const ip = getClientIp(req);
-      const responseSize = parseInt(res.getHeader('content-length') as string) || 0;
+
+      // 优先使用实际发送的字节数，其次使用 content-length 头
+      const responseSize =
+        bytesSent ||
+        parseInt(res.getHeader('content-length') as string) ||
+        0;
 
       const entry = this.accessLogRepository.create({
         ip,

--- a/backend/src/tasks/tasks.module.ts
+++ b/backend/src/tasks/tasks.module.ts
@@ -4,9 +4,11 @@ import { TasksService } from './tasks.service';
 import { BannedIP } from '../common/entities/banned-ip.entity';
 import { ShareAudit } from '../common/entities/share-audit.entity';
 import { RateLimit } from '../common/entities/rate-limit.entity';
+import { AccessLog } from '../common/entities/access-log.entity';
+import { AuditLog } from '../common/entities/audit-log.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([BannedIP, ShareAudit, RateLimit])],
+  imports: [TypeOrmModule.forFeature([BannedIP, ShareAudit, RateLimit, AccessLog, AuditLog])],
   providers: [TasksService],
 })
 export class TasksModule {}

--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -5,6 +5,8 @@ import { Cron, CronExpression } from '@nestjs/schedule';
 import { BannedIP } from '../common/entities/banned-ip.entity';
 import { ShareAudit } from '../common/entities/share-audit.entity';
 import { RateLimit } from '../common/entities/rate-limit.entity';
+import { AccessLog } from '../common/entities/access-log.entity';
+import { AuditLog } from '../common/entities/audit-log.entity';
 
 @Injectable()
 export class TasksService {
@@ -17,6 +19,10 @@ export class TasksService {
     private shareAuditRepository: Repository<ShareAudit>,
     @InjectRepository(RateLimit)
     private rateLimitRepository: Repository<RateLimit>,
+    @InjectRepository(AccessLog)
+    private accessLogRepository: Repository<AccessLog>,
+    @InjectRepository(AuditLog)
+    private auditLogRepository: Repository<AuditLog>,
   ) {}
 
   @Cron(CronExpression.EVERY_30_MINUTES)
@@ -67,6 +73,60 @@ export class TasksService {
       }
     } catch (error: unknown) {
       this.logger.error('清理过期封禁记录失败', error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  /**
+   * 清理过期的访问日志（每天凌晨 2 点执行）
+   * 保留策略：默认保留最近 30 天，可通过 ACCESS_LOG_RETENTION_DAYS 配置
+   */
+  @Cron('0 2 * * *')
+  async cleanupExpiredAccessLogs() {
+    try {
+      const retentionDays = parseInt(process.env.ACCESS_LOG_RETENTION_DAYS || '30', 10);
+      const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+
+      const result = await this.accessLogRepository.delete({
+        createdAt: LessThan(cutoff),
+      });
+
+      if ((result.affected ?? 0) > 0) {
+        this.logger.log(
+          `已清理 ${result.affected} 条过期访问日志（保留期限：${retentionDays} 天）`,
+        );
+      }
+    } catch (error: unknown) {
+      this.logger.error(
+        '清理过期访问日志失败',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  /**
+   * 清理过期的审计日志（每天凌晨 3 点执行）
+   * 保留策略：默认保留最近 90 天，可通过 AUDIT_LOG_RETENTION_DAYS 配置
+   */
+  @Cron('0 3 * * *')
+  async cleanupExpiredAuditLogs() {
+    try {
+      const retentionDays = parseInt(process.env.AUDIT_LOG_RETENTION_DAYS || '90', 10);
+      const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+
+      const result = await this.auditLogRepository.delete({
+        createdAt: LessThan(cutoff),
+      });
+
+      if ((result.affected ?? 0) > 0) {
+        this.logger.log(
+          `已清理 ${result.affected} 条过期审计日志（保留期限：${retentionDays} 天）`,
+        );
+      }
+    } catch (error: unknown) {
+      this.logger.error(
+        '清理过期审计日志失败',
+        error instanceof Error ? error.message : String(error),
+      );
     }
   }
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -45,9 +45,9 @@ const client: AxiosInstance = axios.create({
   baseURL: '/api',
   timeout: 30000,
   withCredentials: true,
-  headers: {
-    'Content-Type': 'application/json',
-  },
+  // 不设置 Content-Type，由 axios 根据请求数据类型自动推断：
+  // - 普通对象 → application/json
+  // - FormData → multipart/form-data（浏览器自动设置 boundary）
 });
 
 // ---- 请求拦截器 ----

--- a/frontend/src/views/admin/AccessLogs.vue
+++ b/frontend/src/views/admin/AccessLogs.vue
@@ -5,14 +5,33 @@
       <p>网站请求量、带宽消耗、独立访客与流量峰值监控</p>
     </div>
 
-    <!-- 时间范围选择器 -->
+    <!-- 时间范围选择器和自动刷新 -->
     <div class="toolbar">
-      <t-radio-group v-model="timeRange" variant="default-filled" @change="onTimeRangeChange">
-        <t-radio-button value="1h">1小时</t-radio-button>
-        <t-radio-button value="24h">24小时</t-radio-button>
-        <t-radio-button value="7d">7天</t-radio-button>
-        <t-radio-button value="30d">30天</t-radio-button>
-      </t-radio-group>
+      <div style="display: flex; gap: 12px; align-items: center; flex-wrap: wrap;">
+        <t-radio-group v-model="timeRange" variant="default-filled" @change="onTimeRangeChange">
+          <t-radio-button value="1h">1小时</t-radio-button>
+          <t-radio-button value="24h">24小时</t-radio-button>
+          <t-radio-button value="7d">7天</t-radio-button>
+          <t-radio-button value="30d">30天</t-radio-button>
+        </t-radio-group>
+        <div style="display: flex; gap: 8px; align-items: center; margin-left: auto;">
+          <label style="font-size: 12px; color: var(--text-secondary); white-space: nowrap;">自动刷新：</label>
+          <t-select
+            v-model="autoRefreshInterval"
+            style="width: 100px;"
+            :popup-props="{ overlayStyle: { minWidth: '100px' } }"
+            @change="updateAutoRefresh"
+          >
+            <t-option :value="0" label="关闭" />
+            <t-option :value="30000" label="30秒" />
+            <t-option :value="60000" label="1分钟" />
+            <t-option :value="300000" label="5分钟" />
+          </t-select>
+          <span v-if="lastRefreshTime" style="font-size: 12px; color: var(--text-secondary); white-space: nowrap;">
+            最后更新：{{ lastRefreshTime }}
+          </span>
+        </div>
+      </div>
     </div>
 
     <!-- 核心指标卡片 -->
@@ -96,9 +115,20 @@
         :loading="loading"
         :pagination="pagination"
         row-key="id"
-        table-layout="auto"
+        table-layout="fixed"
         @page-change="onPageChange"
       >
+        <template #path="{ row }">
+          <div class="path-cell" :title="row.path">
+            <span class="path-text">{{ truncatePath(row.path, 60) }}</span>
+            <t-tooltip v-if="row.path.length > 60" theme="light" placement="top">
+              <template #content>
+                <div style="max-width: 400px; word-break: break-all;">{{ row.path }}</div>
+              </template>
+              <span class="path-info-icon">&#9432;</span>
+            </t-tooltip>
+          </div>
+        </template>
         <template #statusCode="{ row }">
           <t-tag :theme="statusTheme(row.statusCode)" variant="light" size="small">
             {{ row.statusCode }}
@@ -189,11 +219,45 @@ const pieChartRef = ref<HTMLDivElement | null>(null);
 let trendChart: echarts.ECharts | null = null;
 let pieChart: echarts.ECharts | null = null;
 
-// Table columns (mobile-friendly responsive)
+// Auto-refresh
+const autoRefreshInterval = ref(0);
+let autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
+const lastRefreshTime = ref('');
+
+function updateAutoRefresh() {
+  if (autoRefreshTimer) {
+    clearInterval(autoRefreshTimer);
+    autoRefreshTimer = null;
+  }
+  if (autoRefreshInterval.value > 0) {
+    autoRefreshTimer = setInterval(() => {
+      refreshAll();
+    }, autoRefreshInterval.value);
+  }
+}
+
+// Smart path truncation
+function truncatePath(path: string, maxLength: number = 60): string {
+  if (path.length <= maxLength) return path;
+  const [pathname, query] = path.split('?');
+  if (pathname.length > maxLength) {
+    return pathname.substring(0, maxLength - 3) + '...';
+  }
+  if (query) {
+    const available = maxLength - pathname.length - 1;
+    if (available > 5) {
+      return pathname + '?' + query.substring(0, available - 3) + '...';
+    }
+    return pathname + '?...';
+  }
+  return path;
+}
+
+// Table columns (fixed layout with controlled widths)
 const columns = [
   { colKey: 'ip', title: 'IP 地址', width: 140 },
   { colKey: 'method', title: '方法', width: 70 },
-  { colKey: 'path', title: '请求路径', ellipsis: true, minWidth: 160 },
+  { colKey: 'path', title: '请求路径', ellipsis: false, width: 300 },
   { colKey: 'statusCode', title: '状态码', width: 90 },
   { colKey: 'duration', title: '耗时', width: 80 },
   { colKey: 'responseSize', title: '流量', width: 90 },
@@ -426,6 +490,7 @@ function refreshAll() {
   fetchStats();
   fetchTrend();
   fetchLogs();
+  lastRefreshTime.value = new Date().toLocaleTimeString('zh-CN');
 }
 
 // Lifecycle
@@ -434,6 +499,9 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+  if (autoRefreshTimer) {
+    clearInterval(autoRefreshTimer);
+  }
   trendChart?.dispose();
   pieChart?.dispose();
 });
@@ -537,6 +605,36 @@ onUnmounted(() => {
   gap: 12px;
   margin-bottom: 16px;
   flex-wrap: wrap;
+}
+
+/* Path cell styles */
+.path-cell {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.path-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: 'Courier New', monospace;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.path-info-icon {
+  flex-shrink: 0;
+  cursor: help;
+  font-size: 13px;
+  opacity: 0.6;
+  transition: opacity 0.2s;
+}
+
+.path-info-icon:hover {
+  opacity: 1;
 }
 
 /* Responsive */

--- a/frontend/src/views/admin/AuditLogs.vue
+++ b/frontend/src/views/admin/AuditLogs.vue
@@ -46,6 +46,7 @@
         <t-option value="auth_config_change" label="认证配置" />
         <t-option value="ip_ban" label="IP封禁" />
         <t-option value="ip_unban" label="IP解封" />
+        <t-option value="batch_delete_files" label="批量删除" />
       </t-select>
       <t-button variant="outline" @click="onRefresh">刷新</t-button>
     </div>
@@ -81,6 +82,11 @@
           </span>
           <span v-else>-</span>
         </template>
+        <template #username="{ row }">
+          <span v-if="row.username" style="color: var(--text-primary);">{{ row.username }}</span>
+          <span v-else-if="row.userId" :title="row.userId" style="font-size: 11px; color: var(--text-secondary); font-family: monospace;">{{ truncateId(row.userId) }}</span>
+          <span v-else style="color: var(--text-secondary)">匿名</span>
+        </template>
         <template #createdAt="{ row }">
           {{ formatTime(row.createdAt) }}
         </template>
@@ -98,6 +104,7 @@ interface AuditLogItem {
   id: string;
   action: string;
   userId: string | null;
+  username: string | null;
   ip: string | null;
   resourceType: string | null;
   resourceId: string | null;
@@ -124,7 +131,7 @@ const pagination = reactive({
 const columns = [
   { colKey: 'action', title: '操作', width: 110 },
   { colKey: 'status', title: '状态', width: 70 },
-  { colKey: 'userId', title: '用户ID', ellipsis: true, width: 160 },
+  { colKey: 'username', title: '操作用户', ellipsis: true, width: 140 },
   { colKey: 'ip', title: 'IP', width: 130 },
   { colKey: 'resourceType', title: '资源类型', width: 90 },
   { colKey: 'resourceId', title: '资源ID', ellipsis: true, width: 140 },
@@ -187,6 +194,12 @@ function formatTime(dateStr: string): string {
     month: '2-digit', day: '2-digit',
     hour: '2-digit', minute: '2-digit', second: '2-digit',
   });
+}
+
+/** UUID 截断显示（前 8 位 + ...），用于无用户名的降级展示 */
+function truncateId(id: string): string {
+  if (id.length <= 12) return id;
+  return id.substring(0, 8) + '...';
 }
 
 async function fetchLogs() {


### PR DESCRIPTION
- 审计日志关联操作用户名，管理员操作均记录用户ID
- 访问日志与审计日志增加定时自动清理及保留天数配置
- 访问日志中间件追踪实际发送字节数（兼容流式/压缩响应）
- 前端访问统计增加自动刷新，axios 客户端移除默认 Content-Type
- 实体主键改用数据库生成 UUID，修复注册并发查询