### PR TITLE
fix: 修复并发竞态与安全加固

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -48,6 +48,10 @@ APP_URL=http://localhost:3000
 FRONTEND_URL=http://localhost:5173
 # CORS_ORIGINS — 逗号分隔的 CORS 允许来源（优先级高于 FRONTEND_URL）
 CORS_ORIGINS=http://localhost:5173
+# SECURE_COOKIE — 生产环境（HTTPS）设为 true 强制 Cookie secure 标志
+# SECURE_COOKIE=true
+# TOKEN_EXTRACTION_MODE — Token 提取方式：both（Cookie + Bearer，默认）或 cookie_only（仅 Cookie）
+# TOKEN_EXTRACTION_MODE=both
 
 # ==========================================
 # 文件上传配置

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -9,8 +9,11 @@ import { getClientIp } from '../common/utils/client-ip';
 
 const getCookieOptions = (req: Request) => ({
   httpOnly: true,
-  // 请求级动态判断 HTTPS，兼容反向代理（X-Forwarded-Proto）
-  secure: req.secure || req.headers['x-forwarded-proto'] === 'https',
+  // 生产环境建议设置 SECURE_COOKIE=true 强制 secure 标志，
+  // 避免因反向代理未正确设置 X-Forwarded-Proto 导致 Cookie 降级为非 secure
+  secure: process.env.SECURE_COOKIE === 'true' || req.secure || req.headers['x-forwarded-proto'] === 'https',
+  // strict: 浏览器完全不发送跨站请求中的 Cookie，安全性最高
+  // 若需兼容邮件验证链接等跨站场景，可考虑使用 lax
   sameSite: 'strict' as const,
   maxAge: 7 * 24 * 3600 * 1000, // 7 days
   path: '/',

--- a/backend/src/auth/auth.dto.ts
+++ b/backend/src/auth/auth.dto.ts
@@ -26,6 +26,7 @@ export class LoginDto {
   email: string;
 
   @IsString()
+  @MinLength(1, { message: '请输入密码' })
   password: string;
 }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -67,7 +67,7 @@ export class AuthService {
       await this.validateVerificationCode(registerDto.email, registerDto.code, 'register');
     }
 
-    const hashedPassword = await bcrypt.hash(registerDto.password, 10);
+    const hashedPassword = await bcrypt.hash(registerDto.password, 12);
 
     // 使用事务 + 行锁确保超管角色的唯一性
     const queryRunner = this.dataSource.createQueryRunner();
@@ -76,9 +76,9 @@ export class AuthService {
 
     try {
       // 锁定 users 表防止并发注册竞态，确保首个注册用户获得 super_admin
-      // 使用 FOR UPDATE 确保在 REPEATABLE READ 下也能读到最新数据
+      // （LOCK TABLE 提供最高级别的隔离，防止多个事务同时读取空表而竞争首位）
       await queryRunner.query('LOCK TABLE "users" IN EXCLUSIVE MODE');
-      // 表已通过 LOCK TABLE 锁定，无需 FOR UPDATE（PostgreSQL 不允许对聚合函数使用 FOR UPDATE）
+      // PostgreSQL 对 SELECT COUNT(*) 不允许 FOR UPDATE，LOCK TABLE 已提供隔离保证
       const [{ count }] = await queryRunner.query(
         'SELECT COUNT(*) as count FROM "users"',
       );
@@ -193,11 +193,9 @@ export class AuthService {
     }
 
     // 邮箱验证开启时，未验证用户不允许登录
-    if (!user.emailVerified) {
-      const emailVerificationEnabled = await this.getConfigValue('EMAIL_VERIFICATION_ENABLED', 'false');
-      if (emailVerificationEnabled === 'true') {
-        throw new UnauthorizedException('请先验证邮箱');
-      }
+    const emailVerificationEnabled = await this.getConfigValue('EMAIL_VERIFICATION_ENABLED', 'false');
+    if (!user.emailVerified && emailVerificationEnabled === 'true') {
+      throw new UnauthorizedException('请先验证邮箱');
     }
 
     const isPasswordValid = await bcrypt.compare(loginDto.password, user.password);
@@ -293,19 +291,18 @@ export class AuthService {
     const codeHash = this.hashCode(code);
     const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
 
-    await this.verificationCodeRepository.update(
-      { email, type, isUsed: false },
-      { isUsed: true },
-    );
-
-    const verificationCode = this.verificationCodeRepository.create({
-      email,
-      code: codeHash,
-      type,
-      expiresAt,
+    // T2-5: 使用事务确保旧码标记失效和新码插入的原子性，
+    // 防止并发请求在 update 和 save 之间产生两个有效验证码
+    await this.dataSource.transaction(async (manager) => {
+      await manager.update(VerificationCode, { email, type, isUsed: false }, { isUsed: true });
+      const verificationCode = manager.create(VerificationCode, {
+        email,
+        code: codeHash,
+        type,
+        expiresAt,
+      });
+      await manager.save(verificationCode);
     });
-
-    await this.verificationCodeRepository.save(verificationCode);
 
     if (type === 'register' || type === 'reset_password') {
       await this.mailerService.sendVerificationCode(email, code);
@@ -324,7 +321,7 @@ export class AuthService {
   async resetPassword(dto: ResetPasswordDto): Promise<void> {
     await this.validateVerificationCode(dto.email, dto.code, 'reset_password');
 
-    const hashedPassword = await bcrypt.hash(dto.newPassword, 10);
+    const hashedPassword = await bcrypt.hash(dto.newPassword, 12);
     await this.userRepository.update(
       { email: dto.email },
       { password: hashedPassword },

--- a/backend/src/auth/jwt.strategy.ts
+++ b/backend/src/auth/jwt.strategy.ts
@@ -16,11 +16,16 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     configService: ConfigService,
     private authService: AuthService,
   ) {
+    // TOKEN_EXTRACTION_MODE 控制 Token 提取方式：
+    // - 'cookie_only'：仅从 Cookie 提取（推荐生产环境，缩小攻击面）
+    // - 默认（both）：同时支持 Cookie 和 Authorization Header
+    const extractionMode = configService.get<string>('TOKEN_EXTRACTION_MODE', 'both');
+    const extractors = extractionMode === 'cookie_only'
+      ? [cookieExtractor]
+      : [cookieExtractor, ExtractJwt.fromAuthHeaderAsBearerToken()];
+
     super({
-      jwtFromRequest: ExtractJwt.fromExtractors([
-        cookieExtractor,
-        ExtractJwt.fromAuthHeaderAsBearerToken(),
-      ]),
+      jwtFromRequest: ExtractJwt.fromExtractors(extractors),
       ignoreExpiration: false,
       secretOrKey: (() => {
         const secret = configService.get<string>('JWT_SECRET');

--- a/backend/src/common/decorators/current-user.decorator.ts
+++ b/backend/src/common/decorators/current-user.decorator.ts
@@ -1,8 +1,16 @@
-import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { createParamDecorator, ExecutionContext, UnauthorizedException } from '@nestjs/common';
 
+/**
+ * 提取当前认证用户的参数装饰器。
+ * 当 Guard 未正确设置 `request.user` 时返回 undefined，
+ * 调用方应检查 null 或使用 `@UseGuards(JwtAuthGuard)` 确保认证。
+ */
 export const CurrentUser = createParamDecorator(
   (_data: unknown, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();
+    if (!request.user) {
+      throw new UnauthorizedException('用户未认证');
+    }
     return request.user;
   },
 );

--- a/backend/src/common/entities/access-log.entity.ts
+++ b/backend/src/common/entities/access-log.entity.ts
@@ -7,6 +7,9 @@ import {
 } from 'typeorm';
 
 @Entity('access_logs')
+@Index(['createdAt'])
+@Index(['path'])
+@Index(['statusCode'])
 export class AccessLog {
   @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;

--- a/backend/src/common/entities/audit-log.entity.ts
+++ b/backend/src/common/entities/audit-log.entity.ts
@@ -3,6 +3,7 @@ import {
   PrimaryColumn,
   Column,
   CreateDateColumn,
+  Index,
 } from 'typeorm';
 
 /** 审计日志操作类型 */
@@ -42,6 +43,9 @@ export enum AuditStatus {
 }
 
 @Entity('audit_logs')
+@Index(['userId'])
+@Index(['action'])
+@Index(['createdAt'])
 export class AuditLog {
   @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;

--- a/backend/src/common/entities/verification-code.entity.ts
+++ b/backend/src/common/entities/verification-code.entity.ts
@@ -3,9 +3,11 @@ import {
   PrimaryColumn,
   Column,
   CreateDateColumn,
+  Index,
 } from 'typeorm';
 
 @Entity('verification_codes')
+@Index(['email', 'type', 'isUsed'])
 export class VerificationCode {
   @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;

--- a/backend/src/common/guards/jwt-auth.guard.ts
+++ b/backend/src/common/guards/jwt-auth.guard.ts
@@ -1,9 +1,20 @@
-import { Injectable, ExecutionContext } from '@nestjs/common';
+import { Injectable, ExecutionContext, Logger } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
+  private readonly logger = new Logger(JwtAuthGuard.name);
+
   canActivate(context: ExecutionContext) {
-    return super.canActivate(context);
+    const request = context.switchToHttp().getRequest();
+    // 委托 Passport 进行 JWT 验证，并在失败时记录日志
+    const result = super.canActivate(context);
+    Promise.resolve(result).catch((error: unknown) => {
+      const ip = request.ip || 'unknown';
+      const userAgent = (request.headers?.['user-agent'] as string)?.substring(0, 200) || 'unknown';
+      const msg = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`JWT 认证失败 [${ip} UA:${userAgent}]: ${msg}`);
+    });
+    return result;
   }
 }

--- a/backend/src/common/guards/roles.guard.ts
+++ b/backend/src/common/guards/roles.guard.ts
@@ -12,10 +12,17 @@ export class RolesGuard implements CanActivate {
       ROLES_KEY,
       [context.getHandler(), context.getClass()],
     );
+    const { user } = context.switchToHttp().getRequest();
+
     if (!requiredRoles) {
+      // 无 @Roles 装饰器时，至少要求用户已认证（白名单策略）
+      // 防止开发者遗漏装饰器导致端点无角色保护
+      if (!user) {
+        throw new UnauthorizedException('用户未认证');
+      }
       return true;
     }
-    const { user } = context.switchToHttp().getRequest();
+
     if (!user) {
       throw new UnauthorizedException('用户未认证');
     }

--- a/backend/src/common/middleware/access-log.middleware.ts
+++ b/backend/src/common/middleware/access-log.middleware.ts
@@ -5,13 +5,13 @@ import { Repository } from 'typeorm';
 import { AccessLog } from '../entities/access-log.entity';
 import { getClientIp } from '../utils/client-ip';
 
-/** 不记录日志的路径（使用 baseUrl+path 精确匹配，不含查询参数） */
-const SKIP_PATHS = [
+/** 不记录日志的路径集合（使用 originalUrl 路径部分匹配，去除查询参数和尾部斜杠） */
+const SKIP_PATH_SET = new Set([
   '/api/admin/access-logs',
   '/api/admin/access-logs/stats',
   '/api/admin/access-logs/trend',
   '/api/admin/audit-logs',
-];
+]);
 
 @Injectable()
 export class AccessLogMiddleware implements NestMiddleware {
@@ -22,16 +22,18 @@ export class AccessLogMiddleware implements NestMiddleware {
 
   use(req: Request, res: Response, next: NextFunction): void {
     const start = Date.now();
-    // 使用 baseUrl + path 精确匹配路径（不含查询参数），防止查询参数绕过
-    const path = req.baseUrl + req.path;
+    // T1-1/T1-2/T1-3: 使用 originalUrl 获取含全局 /api 前缀的原始路径
+    // 去除查询参数和尾部斜杠，确保路径匹配一致性和统计聚合准确性
+    const rawPath = (req.originalUrl || req.url || '/').split('?')[0].replace(/\/+$/, '') || '/';
 
-    // 跳过自身 API 请求
-    if (SKIP_PATHS.includes(path)) {
+    // T1-5: 使用 Set.has() O(1) 查找替代 Array.includes() O(n)
+    if (SKIP_PATH_SET.has(rawPath)) {
       next();
       return;
     }
 
-    // 通过拦截 write/end 追踪实际发送的字节数（兼容流式响应和 gzip 压缩）
+    // T1-4: 通过拦截 write/end 追踪实际发送的字节数
+    // 注意：统计的是业务层写入字节（压缩前），gzip 压缩后实际网络传输量可能更低
     let bytesSent = 0;
     const originalWrite = res.write.bind(res) as typeof res.write;
     const originalEnd = res.end.bind(res) as typeof res.end;
@@ -55,7 +57,7 @@ export class AccessLogMiddleware implements NestMiddleware {
 
     // 在响应完成时记录日志
     res.on('finish', () => {
-      self.logAsync(req, res, Date.now() - start, path, bytesSent).catch(() => {
+      self.logAsync(req, res, Date.now() - start, rawPath, bytesSent).catch(() => {
         // 日志写入失败不影响业务
       });
     });

--- a/backend/src/common/services/audit.service.ts
+++ b/backend/src/common/services/audit.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AuditLog, AuditAction, AuditStatus } from '../entities/audit-log.entity';
@@ -14,8 +14,10 @@ export interface AuditEntry {
 }
 
 @Injectable()
-export class AuditService {
+export class AuditService implements OnApplicationShutdown {
   private readonly logger = new Logger(AuditService.name);
+  /** 追踪未完成的审计写入 Promise，确保优雅关闭时不丢失数据 */
+  private pendingWrites: Set<Promise<void>> = new Set();
 
   constructor(
     @InjectRepository(AuditLog)
@@ -23,12 +25,38 @@ export class AuditService {
   ) {}
 
   /**
-   * 异步记录审计日志，失败不影响主业务流程
+   * 异步记录审计日志（fire-and-forget），失败不影响主业务流程。
+   * 适用于非关键操作的审计记录。
    */
   log(entry: AuditEntry): void {
-    this.writeLogAsync(entry).catch((error: Error) => {
+    const promise = this.writeLogAsync(entry).catch((error: Error) => {
       this.logger.warn(`审计日志写入失败: ${error.message}`, error.stack);
     });
+    this.pendingWrites.add(promise);
+    promise.finally(() => this.pendingWrites.delete(promise));
+  }
+
+  /**
+   * 同步等待审计日志写入完成。
+   * 适用于高敏感操作（role_change、config_change、delete 等），
+   * 确保审计记录在操作响应前已持久化。
+   */
+  async logAwait(entry: AuditEntry): Promise<void> {
+    try {
+      await this.writeLogAsync(entry);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`审计日志写入失败（await）: ${message}`);
+      // 不抛出，避免影响主业务返回
+    }
+  }
+
+  async onApplicationShutdown(_signal?: string): Promise<void> {
+    if (this.pendingWrites.size > 0) {
+      this.logger.log(`等待 ${this.pendingWrites.size} 条审计日志写入完成...`);
+      await Promise.allSettled(this.pendingWrites);
+      this.logger.log('所有待处理审计日志已写入');
+    }
   }
 
   private async writeLogAsync(entry: AuditEntry): Promise<void> {
@@ -49,14 +77,16 @@ export class AuditService {
   }
 
   /**
-   * 批量记录审计日志
+   * 批量异步记录审计日志
    */
   logBatch(entries: AuditEntry[]): void {
     if (entries.length === 0) return;
 
-    this.writeBatchAsync(entries).catch((error: Error) => {
+    const promise = this.writeBatchAsync(entries).catch((error: Error) => {
       this.logger.warn(`批量审计日志写入失败: ${error.message}`, error.stack);
     });
+    this.pendingWrites.add(promise);
+    promise.finally(() => this.pendingWrites.delete(promise));
   }
 
   private async writeBatchAsync(entries: AuditEntry[]): Promise<void> {

--- a/backend/src/common/services/config-cache.service.ts
+++ b/backend/src/common/services/config-cache.service.ts
@@ -39,9 +39,24 @@ export class ConfigCacheService {
   async setBatch(
     configs: { key: string; value: string; description?: string }[],
   ): Promise<void> {
-    for (const config of configs) {
-      await this.set(config.key, config.value, config.description);
+    if (configs.length === 0) return;
+
+    // 批量 upsert：一次数据库操作完成所有写入
+    const entities = configs.map((c) => ({
+      key: c.key,
+      value: c.value,
+      description: c.description ?? undefined,
+      updatedAt: new Date(),
+    }));
+    await this.systemConfigRepository.upsert(entities, ['key']);
+
+    // 批量更新缓存
+    for (const c of configs) {
+      this.cache.set(c.key, c.value);
     }
+
+    // 单次事件通知批量变更
+    this.eventEmitter.emit('config.batch-changed', configs);
   }
 
   invalidate(key: string): void {

--- a/backend/src/common/services/rate-limit.service.ts
+++ b/backend/src/common/services/rate-limit.service.ts
@@ -19,7 +19,9 @@ export class RateLimitService {
 
   /**
    * 原子检查并递增限流计数。
-   * 如果窗口已过期则重置；如果在锁定中则拒绝；否则递增计数并在达到阈值时锁定。
+   * 使用单一 UPSERT（含 RETURNING）完成：计数递增 + 阈值锁定 + 窗口重置。
+   * lockedUntil 通过 CASE WHEN 在 ON CONFLICT DO UPDATE 中原子化设置，
+   * 消除了原 isLocked→findOne 的 TOCTOU 窗口和达到阈值后独立 UPDATE 的非原子问题。
    *
    * @param key   限流键（如 login:ip:email）
    * @param type  类型标签
@@ -37,9 +39,8 @@ export class RateLimitService {
     const now = new Date();
     const windowStart = new Date(now.getTime() - windowMs);
 
-    // 使用单一原子化 SQL 操作处理并发，避免竞态条件
-    // 如果窗口已过期 → 重置计数为 1；否则递增计数
-    // 如果已锁定 → 不更新（WHERE 条件过滤）
+    // 单一原子化 UPSERT：计数递增、窗口重置、阈值锁定均在同一个 SQL 中完成
+    // lockedUntil 通过 CASE WHEN 在 DO UPDATE 中原子化计算，无需后续独立 UPDATE
     const result = await this.rateLimitRepo.manager.query(
       `INSERT INTO rate_limits ("key", "type", "attemptCount", "firstAttemptAt", "lockedUntil", "updatedAt")
        VALUES ($1, $2, 1, $3, NULL, NOW())
@@ -52,44 +53,43 @@ export class RateLimitService {
            WHEN rate_limits."firstAttemptAt" < $4::timestamp THEN $3::timestamp
            ELSE rate_limits."firstAttemptAt"
          END,
+         "lockedUntil" = CASE
+           WHEN rate_limits."firstAttemptAt" < $4::timestamp THEN NULL
+           WHEN rate_limits."attemptCount" + 1 >= $5 THEN NOW() + ($6 || ' milliseconds')::interval
+           ELSE rate_limits."lockedUntil"
+         END,
          "updatedAt" = NOW()
        WHERE rate_limits."lockedUntil" IS NULL
           OR rate_limits."lockedUntil" < NOW()
        RETURNING "attemptCount", "firstAttemptAt", "lockedUntil"`,
-      [key, type, now, windowStart],
+      [key, type, now, windowStart, maxAttempts, lockDurationMs.toString()],
     );
 
-    // 如果无返回行，说明记录处于锁定状态（WHERE 条件不满足）
+    // 无返回行 → 记录已被其他请求锁定（WHERE 条件过滤了锁定记录）
+    // 锁定时间使用 lockDurationMs 近似（已原子化设置，无 TOCTOU）
     if (!result || result.length === 0) {
-      const locked = await this.rateLimitRepo.findOne({ where: { key } });
-      if (locked?.lockedUntil && now < locked.lockedUntil) {
-        const waitMinutes = Math.ceil((locked.lockedUntil.getTime() - now.getTime()) / 60000);
-        return { allowed: false, waitMinutes };
-      }
-      // 理论上不应到达，兜底拒绝
-      return { allowed: false, waitMinutes: 1 };
+      const waitMinutes = Math.ceil((lockDurationMs || 15 * 60 * 1000) / 60000);
+      return { allowed: false, waitMinutes };
     }
 
     const row = result[0];
     const count = row.attemptCount;
+    const lockedUntil = row.lockedUntil ? new Date(row.lockedUntil) : null;
 
-    // 窗口内的首次尝试，但已被 CASE 重置为 1（窗口过期场景）
+    // 检测本次操作是否已达到阈值并原子化设置了锁
+    if (lockedUntil && now < lockedUntil) {
+      const waitMinutes = Math.ceil((lockedUntil.getTime() - now.getTime()) / 60000);
+      return { allowed: false, waitMinutes };
+    }
+
+    // 窗口过期后重置为 1，判断是否为刚重置场景
     if (count === 1 && row.firstAttemptAt) {
       const firstAttemptAt = new Date(row.firstAttemptAt);
       // 使用窗口时长的 1% 作为"刚刚重置"的阈值，至少 100ms，最多 1000ms
       const justResetThreshold = Math.min(1000, Math.max(100, windowMs / 100));
       if (now.getTime() - firstAttemptAt.getTime() < justResetThreshold) {
-        // 刚刚重置，视为窗口内第一次
         return { allowed: true };
       }
-    }
-
-    // 达到阈值 → 锁定
-    if (count >= maxAttempts) {
-      const lockedUntil = new Date(now.getTime() + lockDurationMs);
-      await this.rateLimitRepo.update({ key }, { lockedUntil });
-      const waitMinutes = Math.ceil(lockDurationMs / 60000);
-      return { allowed: false, waitMinutes };
     }
 
     return { allowed: true };

--- a/backend/src/common/utils/client-ip.ts
+++ b/backend/src/common/utils/client-ip.ts
@@ -2,25 +2,20 @@ import { Request } from 'express';
 
 /**
  * 安全地提取真实客户端 IP 地址
- * 优先使用可信代理头（X-Forwarded-For），回退到直接连接 IP
+ * 优先使用 Express trust proxy 解析的 req.ips（需 app.set('trust proxy', ...) 配置），
+ * 回退到可信代理头，最后使用直接连接 IP
  */
 export function getClientIp(req: Request): string {
-  // 1. X-Forwarded-For（取第一个非信任代理 IP）
-  const forwardedFor = req.headers['x-forwarded-for'];
-  if (forwardedFor) {
-    const forwardedStr = typeof forwardedFor === 'string'
-      ? forwardedFor
-      : forwardedFor[0];
-    if (forwardedStr) {
-      const ips = forwardedStr.split(',').map((ip) => ip.trim());
-      const clientIp = ips[0]; // 最左侧为原始客户端 IP
-      if (isValidIp(clientIp)) {
-        return clientIp;
-      }
+  // 1. Express trust proxy 解析的 req.ips（信任链由 trust proxy 配置控制）
+  //    最后一个元素为最接近代理的 IP，防止客户端伪造 X-Forwarded-For
+  if (req.ips && req.ips.length > 0) {
+    const trustedClientIp = req.ips[0];
+    if (isValidIp(trustedClientIp)) {
+      return trustedClientIp;
     }
   }
 
-  // 2. X-Real-IP（部分代理设置）
+  // 2. X-Real-IP（部分代理设置，较难伪造）
   const realIp = req.headers['x-real-ip'];
   if (realIp) {
     const realIpStr = typeof realIp === 'string' ? realIp : realIp[0];
@@ -29,7 +24,7 @@ export function getClientIp(req: Request): string {
     }
   }
 
-  // 3. CF-Connecting-IP（Cloudflare）
+  // 3. CF-Connecting-IP（Cloudflare，由 Cloudflare 边缘设置）
   const cfIp = req.headers['cf-connecting-ip'];
   if (cfIp) {
     const cfIpStr = typeof cfIp === 'string' ? cfIp : cfIp[0];

--- a/backend/src/file/file.service.ts
+++ b/backend/src/file/file.service.ts
@@ -603,34 +603,28 @@ export class FileService implements OnModuleInit {
       this.BAN_COUNT_LIMIT, 0, this.BAN_WINDOW,
     );
 
-    // 获取当前错误计数和封禁计数
+    // 获取当前错误计数和封禁计数（RateLimitService 已原子化）
     const now = Date.now();
     const currentBanCount = await this.rateLimitService.getAttemptCount(banLimitKey);
 
+    // T3-5: 使用 UPSERT 原子化封禁记录的创建/更新，消除 findOne→save 的 TOCTOU 窗口
     if (currentBanCount >= this.BAN_COUNT_LIMIT) {
       // 第5次封禁 → 升级为6小时
       const expiresAt = new Date(now + this.BAN_6H);
       const reason = `密码错误${this.ERROR_LIMIT}次，1小时内第${currentBanCount}次触发封禁，升级为6小时`;
-
-      const existingBan = await this.bannedIPRepository.findOne({ where: { ip } });
-      if (existingBan) {
-        await this.bannedIPRepository.update(existingBan.id, { expiresAt, reason });
-      } else {
-        await this.bannedIPRepository.save({ ip, reason, isPermanent: false, expiresAt } as BannedIP);
-      }
-
+      await this.bannedIPRepository.upsert(
+        { ip, reason, isPermanent: false, expiresAt } as BannedIP,
+        ['ip'],
+      );
       await this.rateLimitService.reset(banLimitKey);
     } else {
       // 第1-4次封禁 → 5分钟
       const expiresAt = new Date(now + this.BAN_5M);
       const reason = `密码错误${this.ERROR_LIMIT}次，1小时内第${currentBanCount}次触发封禁`;
-
-      const existingBan = await this.bannedIPRepository.findOne({ where: { ip } });
-      if (existingBan) {
-        await this.bannedIPRepository.update(existingBan.id, { expiresAt, reason });
-      } else {
-        await this.bannedIPRepository.save({ ip, reason, isPermanent: false, expiresAt } as BannedIP);
-      }
+      await this.bannedIPRepository.upsert(
+        { ip, reason, isPermanent: false, expiresAt } as BannedIP,
+        ['ip'],
+      );
     }
 
     // 重置错误计数器
@@ -859,15 +853,19 @@ export class FileService implements OnModuleInit {
             userId: '',
             action: 'consume',
             ip: '',
-          });
-        } catch (dbError) {
-          // 唯一约束冲突 = token 已被消费
-          throw new Error('access token 已被使用过');
+          } as ShareAudit);
+        } catch (dbError: unknown) {
+          // PostgreSQL unique_violation (23505) = token 已被消费
+          const code = (dbError as { code?: string }).code;
+          if (code === '23505') {
+            throw new ForbiddenException('访问链接已被使用，请重新获取');
+          }
+          throw dbError;
         }
       }
     } catch (error) {
-      if (error instanceof Error && error.message.includes('已被使用过')) {
-        throw new ForbiddenException('访问链接已被使用，请重新获取');
+      if (error instanceof ForbiddenException) {
+        throw error;
       }
       throw new ForbiddenException('访问链接已失效，请重新获取');
     }

--- a/backend/src/file/upload-job.service.ts
+++ b/backend/src/file/upload-job.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
 import { User } from '../common/entities/user.entity';
 
@@ -15,13 +15,21 @@ export interface UploadJob {
 }
 
 @Injectable()
-export class UploadJobService implements OnModuleInit {
+export class UploadJobService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(UploadJobService.name);
   private jobs = new Map<string, UploadJob>();
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
   onModuleInit() {
-    // 每 5 分钟清理一次已完成/失败的过期任务
-    setInterval(() => this.cleanup(), 5 * 60 * 1000);
+    // 每 5 分钟清理一次过期任务
+    this.cleanupTimer = setInterval(() => this.cleanup(), 5 * 60 * 1000);
+  }
+
+  onModuleDestroy() {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
   }
 
   createJob(user: User, filename: string, fileCount: number = 1): UploadJob {
@@ -52,12 +60,20 @@ export class UploadJobService implements OnModuleInit {
   }
 
   /**
-   * 清理超过 30 分钟的已完成/失败任务
+   * 清理过期任务：
+   * - 超过 30 分钟的已完成/失败任务
+   * - 超过 60 分钟的 pending/uploading 任务（进程异常退出卡住的任务）
    */
   cleanup() {
-    const cutoff = Date.now() - 30 * 60 * 1000;
+    const completedCutoff = Date.now() - 30 * 60 * 1000;
+    const stuckCutoff = Date.now() - 60 * 60 * 1000;
     for (const [id, job] of this.jobs) {
-      if ((job.status === 'completed' || job.status === 'failed') && job.updatedAt.getTime() < cutoff) {
+      const updated = job.updatedAt.getTime();
+      if ((job.status === 'completed' || job.status === 'failed') && updated < completedCutoff) {
+        this.jobs.delete(id);
+      }
+      if ((job.status === 'pending' || job.status === 'uploading') && updated < stuckCutoff) {
+        this.logger.warn(`清理卡住的上传任务 ${id}: ${job.filename} (状态: ${job.status})`);
         this.jobs.delete(id);
       }
     }

--- a/backend/src/migrations/1783000000000-AddPerformanceIndexes.ts
+++ b/backend/src/migrations/1783000000000-AddPerformanceIndexes.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPerformanceIndexes1783000000000 implements MigrationInterface {
+    name = 'AddPerformanceIndexes1783000000000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // T6-2: verification_codes — 加速验证码查询 (email + type + isUsed)
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_verification_codes_email_type_isUsed" ON "verification_codes" ("email", "type", "isUsed")`);
+        // T6-4: audit_logs — 加速按 userId/action/time 筛选
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_audit_logs_userId" ON "audit_logs" ("userId")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_audit_logs_action" ON "audit_logs" ("action")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_audit_logs_createdAt" ON "audit_logs" ("createdAt")`);
+        // T6-3: access_logs — 加速统计查询
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_access_logs_createdAt" ON "access_logs" ("createdAt")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_access_logs_path" ON "access_logs" ("path")`);
+        await queryRunner.query(`CREATE INDEX IF NOT EXISTS "IDX_access_logs_statusCode" ON "access_logs" ("statusCode")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_access_logs_statusCode"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_access_logs_path"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_access_logs_createdAt"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_audit_logs_createdAt"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_audit_logs_action"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_audit_logs_userId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_verification_codes_email_type_isUsed"`);
+    }
+
+}

--- a/backend/src/tasks/tasks.service.ts
+++ b/backend/src/tasks/tasks.service.ts
@@ -79,20 +79,32 @@ export class TasksService {
   /**
    * 清理过期的访问日志（每天凌晨 2 点执行）
    * 保留策略：默认保留最近 30 天，可通过 ACCESS_LOG_RETENTION_DAYS 配置
+   * 使用分批删除防止大表一次性 DELETE 导致长事务和大量 WAL
    */
   @Cron('0 2 * * *')
   async cleanupExpiredAccessLogs() {
     try {
       const retentionDays = parseInt(process.env.ACCESS_LOG_RETENTION_DAYS || '30', 10);
       const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+      const BATCH_SIZE = 1000;
 
-      const result = await this.accessLogRepository.delete({
-        createdAt: LessThan(cutoff),
-      });
+      let totalDeleted = 0;
+      let batchDeleted: number;
+      do {
+        const result = await this.accessLogRepository
+          .createQueryBuilder()
+          .delete()
+          .where('id IN (SELECT id FROM access_logs WHERE "createdAt" < :cutoff LIMIT :limit)')
+          .setParameter('cutoff', cutoff)
+          .setParameter('limit', BATCH_SIZE)
+          .execute();
+        batchDeleted = result.affected ?? 0;
+        totalDeleted += batchDeleted;
+      } while (batchDeleted === BATCH_SIZE);
 
-      if ((result.affected ?? 0) > 0) {
+      if (totalDeleted > 0) {
         this.logger.log(
-          `已清理 ${result.affected} 条过期访问日志（保留期限：${retentionDays} 天）`,
+          `已清理 ${totalDeleted} 条过期访问日志（保留期限：${retentionDays} 天）`,
         );
       }
     } catch (error: unknown) {
@@ -106,20 +118,32 @@ export class TasksService {
   /**
    * 清理过期的审计日志（每天凌晨 3 点执行）
    * 保留策略：默认保留最近 90 天，可通过 AUDIT_LOG_RETENTION_DAYS 配置
+   * 使用分批删除防止大表一次性 DELETE 导致长事务和大量 WAL
    */
   @Cron('0 3 * * *')
   async cleanupExpiredAuditLogs() {
     try {
       const retentionDays = parseInt(process.env.AUDIT_LOG_RETENTION_DAYS || '90', 10);
       const cutoff = new Date(Date.now() - retentionDays * 24 * 60 * 60 * 1000);
+      const BATCH_SIZE = 1000;
 
-      const result = await this.auditLogRepository.delete({
-        createdAt: LessThan(cutoff),
-      });
+      let totalDeleted = 0;
+      let batchDeleted: number;
+      do {
+        const result = await this.auditLogRepository
+          .createQueryBuilder()
+          .delete()
+          .where('id IN (SELECT id FROM audit_logs WHERE "createdAt" < :cutoff LIMIT :limit)')
+          .setParameter('cutoff', cutoff)
+          .setParameter('limit', BATCH_SIZE)
+          .execute();
+        batchDeleted = result.affected ?? 0;
+        totalDeleted += batchDeleted;
+      } while (batchDeleted === BATCH_SIZE);
 
-      if ((result.affected ?? 0) > 0) {
+      if (totalDeleted > 0) {
         this.logger.log(
-          `已清理 ${result.affected} 条过期审计日志（保留期限：${retentionDays} 天）`,
+          `已清理 ${totalDeleted} 条过期审计日志（保留期限：${retentionDays} 天）`,
         );
       }
     } catch (error: unknown) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,7 +10,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onErrorCaptured } from 'vue';
+import { ref, onErrorCaptured, onUnmounted } from 'vue';
+import { useAuthStore } from './stores/auth';
+
+const authStore = useAuthStore();
 
 const globalConfig = ref({
   theme: 'dark',
@@ -24,6 +27,10 @@ onErrorCaptured((err) => {
   errorMessage.value = err instanceof Error ? err.message : String(err);
   console.error('[App Error Boundary]', err);
   return false; // 阻止错误继续向上传播
+});
+
+onUnmounted(() => {
+  authStore.closeAuthChannel();
 });
 
 function reload() {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -43,6 +43,8 @@ export function clearRedirectState() {
 // ---- 创建 axios 实例 ----
 const client: AxiosInstance = axios.create({
   baseURL: '/api',
+  // 默认 30 秒超时。文件上传请求应在调用处覆盖 timeout: 0
+  // （使用后端 HTTP 服务器 10 分钟超时），避免大文件上传被中断
   timeout: 30000,
   withCredentials: true,
   // 不设置 Content-Type，由 axios 根据请求数据类型自动推断：
@@ -88,13 +90,13 @@ client.interceptors.response.use(
 
     // 网络错误（无响应）
     if (!error.response) {
-      console.error('[API] 网络错误:', error.message);
+      console.warn('[API] 网络错误，请检查网络连接:', error.message || '未知错误');
       return Promise.reject(error);
     }
 
     // 服务器错误 (5xx)
     if (status && status >= 500) {
-      console.error('[API] 服务器错误:', status, error.config?.url);
+      console.warn('[API] 服务器错误，请稍后重试:', status, error.config?.url);
       return Promise.reject(error);
     }
 

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -36,6 +36,12 @@ export const useAuthStore = defineStore('auth', () => {
     const response = await api.post('/auth/login', { email, password });
     user.value = response.data.data.user as User;
     clearRedirectState(); // 登录成功后重置重定向状态
+    // 二次验证：通过 fetchUser 获取服务端权威用户状态，防止响应篡改
+    try {
+      await fetchUser();
+    } catch {
+      // fetchUser 失败不影响登录流程（auth/me 主要用于验证状态）
+    }
     return response.data;
   }
 
@@ -58,8 +64,13 @@ export const useAuthStore = defineStore('auth', () => {
     try {
       const response = await api.get('/auth/me');
       user.value = response.data.data as User;
-    } catch {
-      user.value = null;
+    } catch (err: unknown) {
+      // 区分 401（token 过期/无效）和网络错误（临时网络问题）
+      // 仅 401 时清除用户状态，网络错误保留当前状态防止无故登出
+      const axiosErr = err as { response?: { status?: number } };
+      if (axiosErr?.response?.status === 401 || axiosErr?.response?.status === 403) {
+        user.value = null;
+      }
     } finally {
       initialized.value = true;
     }

--- a/frontend/src/views/user/Upload.vue
+++ b/frontend/src/views/user/Upload.vue
@@ -325,8 +325,15 @@ async function convertToMarkdown() {
 }
 
 function copyMarkdown() {
-  navigator.clipboard.writeText(markdownResult.value);
-  MessagePlugin.success('已复制到剪贴板');
+  if (!navigator.clipboard) {
+    MessagePlugin.warning('当前浏览器不支持剪贴板操作，请手动复制');
+    return;
+  }
+  navigator.clipboard.writeText(markdownResult.value).then(() => {
+    MessagePlugin.success('已复制到剪贴板');
+  }).catch(() => {
+    MessagePlugin.warning('复制失败，请手动选择文本复制');
+  });
 }
 
 async function fetchUploadConfig() {


### PR DESCRIPTION
- 使用事务和 UPSERT 消除验证码、限流、封禁记录的 TOCTOU 竞态
- 增加 SECURE_COOKIE 和 TOKEN_EXTRACTION_MODE 配置增强认证安全
- 提升密码哈希轮次至 12，补全登录密码非空校验
- 审计服务支持同步写入与优雅关闭，防止日志丢失
- 添加数据库索引优化查询，日志清理改为分批删除
- 修复 RolesGuard 白名单遗漏认证检查及 CurrentUser 空值处理
- 修复客户端 IP 提取逻辑，优先使用 req.ips 防伪造
- 清理前端资源泄漏并优化 API 错误提示