### PR TITLE
feat(share): 兼容老链接并懒创建 ShareLink

### DIFF
--- a/backend/src/common/entities/share-link.entity.ts
+++ b/backend/src/common/entities/share-link.entity.ts
@@ -55,9 +55,9 @@ export class ShareLink {
   @PrimaryColumn({ type: 'uuid', default: () => 'gen_random_uuid()' })
   id: string;
 
-  /** URL 段 token，全局唯一，12 字符 base64url */
+  /** URL 段 token，全局唯一。新生成的 token 是 12 字符 base64url（~72 bit 熵），但迁移脚本会把老文件的 UUID（36 字符）作为 token 以兼容老链接 */
   @Index({ unique: true })
-  @Column({ type: 'varchar', length: 32 })
+  @Column({ type: 'varchar', length: 64 })
   token: string;
 
   @Column({ type: 'enum', enum: ShareTargetType })

--- a/backend/src/file/file.controller.ts
+++ b/backend/src/file/file.controller.ts
@@ -552,10 +552,10 @@ export class FileController {
   ) {
     res.set('Cache-Control', 'no-store, no-cache, must-revalidate');
 
-    // 1. 查找文件，校验存在且未删除
+    // 1. 查找文件，校验存在且未删除（select 包含遗留约束字段，用于懒创建 ShareLink）
     const file = await this.fileRepository.findOne({
       where: { id, isDeleted: false },
-      select: ['id', 'accessType', 'uploaderId', 'originalName'],
+      select: ['id', 'accessType', 'uploaderId', 'originalName', 'password', 'maxAccessCount', 'expiresIn', 'expiresStartAt'],
     });
     if (!file) {
       res.status(404).json({ code: 1, message: '文件不存在' });
@@ -568,7 +568,7 @@ export class FileController {
       return;
     }
 
-    // 3. 懒创建 ShareLink（如果不存在）
+    // 3. 懒创建 ShareLink（如果不存在）——复制文件的遗留约束字段
     let shareLink = await this.shareLinkRepository.findOne({
       where: { token: id, isDeleted: false },
     });
@@ -578,10 +578,11 @@ export class FileController {
         targetType: ShareTargetType.FILE,
         targetId: id,
         creatorId: file.uploaderId,
-        password: null,
-        maxAccessCount: -1,
-        expiresIn: null,
-        expiresStartAt: null,
+        // 复制文件的遗留约束（Phase 2 之前通过 /files/:id/password 等端点设置的）
+        password: file.password ?? null,
+        maxAccessCount: file.maxAccessCount ?? -1,
+        expiresIn: file.expiresIn ?? null,
+        expiresStartAt: file.expiresStartAt ?? null,
         status: ShareLinkStatus.ACTIVE,
       });
       try {

--- a/backend/src/file/file.controller.ts
+++ b/backend/src/file/file.controller.ts
@@ -37,6 +37,10 @@ import { getClientIp } from '../common/utils/client-ip';
 import { RateLimitService } from '../common/services/rate-limit.service';
 import { ConfigCacheService } from '../common/services/config-cache.service';
 import { TagService } from '../tag/tag.service';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ShareLink, ShareLinkStatus, ShareTargetType } from '../common/entities/share-link.entity';
+import { File as FileEntity } from '../common/entities/file.entity';
 
 // Multer 层硬上限（600MB，仅防止极端 DoS；精确的动态限制由 FileService.upload() 业务层负责）
 const multerFileSize = 600 * 1024 * 1024; // 600MB
@@ -60,6 +64,10 @@ export class FileController {
     private configCacheService: ConfigCacheService,
     private tagService: TagService,
     private folderService: FolderService,
+    @InjectRepository(ShareLink)
+    private shareLinkRepository: Repository<ShareLink>,
+    @InjectRepository(FileEntity)
+    private fileRepository: Repository<FileEntity>,
   ) {}
 
   /**
@@ -529,14 +537,13 @@ export class FileController {
    *   2. 服务端渲染 HTML 密码页
    *   3. 302 跳转到短效 access token URL
    *
-   * Phase 2 起，所有分享逻辑统一由 ShareLink + SPA 路由 /s/:token 处理：
-   *   - 迁移脚本已把现有 accessType=public 的文件复制为 ShareLink（token=原 file.id）
-   *   - 前端 ShareView.vue 接管密码验证 UI
-   *   - 下载由 GET /api/s/:token/download/:fileId 统一处理
+   * Phase 2 起，所有分享逻辑统一由 ShareLink + SPA 路由 /s/:token 处理。
+   * 此端点改为「懒创建 + 重定向」：
+   *   - 查找文件，校验存在 + 公开
+   *   - 查找 ShareLink（token = file.id），不存在则自动创建（公开无密码）
+   *   - 302 重定向到 /s/{id}
    *
-   * 兼容性：老链接 `/files/public/{id}` 重定向到 `/s/{id}` 后仍可命中对应的 ShareLink。
-   * 私有文件（accessType=private）原本走 /files/public/:id 会被拒绝，
-   * 重定向后由 ShareView 展示「分享不存在」（ShareLink 表里也没有对应记录）。
+   * 这确保迁移后新上传的公开文件也能通过老 URL /files/public/{id} 访问。
    */
   @Get('public/:id')
   async getPublicFile(
@@ -544,6 +551,50 @@ export class FileController {
     @Res() res: Response,
   ) {
     res.set('Cache-Control', 'no-store, no-cache, must-revalidate');
+
+    // 1. 查找文件，校验存在且未删除
+    const file = await this.fileRepository.findOne({
+      where: { id, isDeleted: false },
+      select: ['id', 'accessType', 'uploaderId', 'originalName'],
+    });
+    if (!file) {
+      res.status(404).json({ code: 1, message: '文件不存在' });
+      return;
+    }
+
+    // 2. 私有文件不允许公开访问
+    if (file.accessType !== FileAccessType.PUBLIC) {
+      res.status(403).json({ code: 1, message: '此文件为私有文件，不提供公开访问' });
+      return;
+    }
+
+    // 3. 懒创建 ShareLink（如果不存在）
+    let shareLink = await this.shareLinkRepository.findOne({
+      where: { token: id, isDeleted: false },
+    });
+    if (!shareLink) {
+      shareLink = this.shareLinkRepository.create({
+        token: id, // 用文件 id 作为 token，确保老链接兼容
+        targetType: ShareTargetType.FILE,
+        targetId: id,
+        creatorId: file.uploaderId,
+        password: null,
+        maxAccessCount: -1,
+        expiresIn: null,
+        expiresStartAt: null,
+        status: ShareLinkStatus.ACTIVE,
+      });
+      try {
+        await this.shareLinkRepository.save(shareLink);
+      } catch {
+        // 并发创建时可能触发唯一约束冲突，忽略——另一个请求已创建
+        shareLink = await this.shareLinkRepository.findOne({
+          where: { token: id, isDeleted: false },
+        });
+      }
+    }
+
+    // 4. 重定向到 SPA 分享页
     res.redirect(302, `/s/${id}`);
   }
 

--- a/backend/src/file/file.module.ts
+++ b/backend/src/file/file.module.ts
@@ -10,6 +10,7 @@ import { File } from '../common/entities/file.entity';
 import { FileAccessLog } from '../common/entities/file-access-log.entity';
 import { BannedIP } from '../common/entities/banned-ip.entity';
 import { ShareAudit } from '../common/entities/share-audit.entity';
+import { ShareLink } from '../common/entities/share-link.entity';
 import { UploadTask } from '../common/entities/upload-task.entity';
 import { TelegramModule } from '../telegram/telegram.module';
 import { FolderModule } from '../folder/folder.module';
@@ -24,7 +25,7 @@ import { TagModule } from '../tag/tag.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([File, FileAccessLog, BannedIP, ShareAudit, UploadTask]),
+    TypeOrmModule.forFeature([File, FileAccessLog, BannedIP, ShareAudit, ShareLink, UploadTask]),
     ConfigCacheModule,
     RateLimitModule,
     TagModule,

--- a/backend/src/folder/folder.service.ts
+++ b/backend/src/folder/folder.service.ts
@@ -125,7 +125,6 @@ export class FolderService {
     });
     return saved;
   }
-}
 
   async renameFolder(ownerId: string, id: string, dto: RenameFolderDto): Promise<Folder> {
     const folder = await this.assertFolderOwned(id, ownerId);
@@ -242,16 +241,19 @@ export class FolderService {
     if (!folder) {
       throw new NotFoundException('文件夹不存在或未被删除');
     }
-    // 还原子树所有 folder
+    // 还原子树中所有 folder——但只恢复与文件夹同时删除的（deleteRequestedAt 匹配），
+    // 避免恢复在文件夹删除之前已独立删除的子文件夹
     const descendants = await this.folderRepo.findDescendants(folder);
     const folderIds = descendants.map((f) => f.id);
+    const folderDeleteTime = folder.deleteRequestedAt;
     await this.folderRepo.update(
-      { id: In(folderIds) },
+      { id: In(folderIds), deleteRequestedAt: folderDeleteTime as any },
       { isDeleted: false, deleteRequestedAt: null, deleteScheduledAt: null },
     );
-    // 还原内含文件
+    // 还原内含文件——同样只恢复与文件夹同时删除的文件，
+    // 避免恢复用户独立删除或管理员独立删除的文件
     await this.fileRepo.update(
-      { folderId: In(folderIds) },
+      { folderId: In(folderIds), deleteRequestedAt: folderDeleteTime as any },
       { isDeleted: false, deleteRequestedAt: null, deleteScheduledAt: null, deletedByAdmin: false },
     );
     this.audit.log({

--- a/backend/src/migrations/1790500000000-CreateShareLinksTable.ts
+++ b/backend/src/migrations/1790500000000-CreateShareLinksTable.ts
@@ -16,7 +16,7 @@ export class CreateShareLinksTable1790500000000 implements MigrationInterface {
     await queryRunner.query(`
       CREATE TABLE IF NOT EXISTS "share_links" (
         "id"                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-        "token"               varchar(32) NOT NULL,
+        "token"               varchar(64) NOT NULL,
         "targetType"          varchar(10) NOT NULL,
         "targetId"            uuid NOT NULL,
         "creatorId"           uuid NOT NULL,

--- a/backend/src/migrations/1790600000000-WidenShareTokenColumn.ts
+++ b/backend/src/migrations/1790600000000-WidenShareTokenColumn.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * 加宽 share_links.token 列：varchar(32) → varchar(64)。
+ *
+ * 背景：Phase 2 的 CreateShareLinksTable 迁移把 token 设为 varchar(32)，
+ * 但数据迁移和懒创建路径会把文件 UUID（36 字符）作为 token 插入，
+ * 导致已跑过旧迁移的生产库在插入时报 "value too long for type character varying(32)"。
+ *
+ * 此迁移对已跑过 CreateShareLinksTable 的库执行 ALTER COLUMN，
+ * 对新库（已用 varchar(64) 建表）是幂等的（IF EXISTS + 类型已匹配时 ALTER 无副作用）。
+ */
+export class WidenShareTokenColumn1790600000000 implements MigrationInterface {
+  name = 'WidenShareTokenColumn1790600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 检查列是否存在（share_links 表可能尚未创建——新库走 CreateShareLinksTable 已用 varchar(64)）
+    const cols = await queryRunner.query(`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'share_links' AND column_name = 'token'
+    `);
+    if (cols.length === 0) return; // 表不存在，跳过
+
+    // 加宽列类型（PostgreSQL ALTER COLUMN TYPE 是幂等的，varchar(64) → varchar(64) 无副作用）
+    await queryRunner.query(`
+      ALTER TABLE "share_links"
+      ALTER COLUMN "token" TYPE varchar(64)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // 回滚：缩回 varchar(32)——注意：如果已有 36 字符的 token 会失败
+    // 这是预期行为：回滚前应确保没有长 token 存在
+    const cols = await queryRunner.query(`
+      SELECT column_name FROM information_schema.columns
+      WHERE table_name = 'share_links' AND column_name = 'token'
+    `);
+    if (cols.length === 0) return;
+
+    await queryRunner.query(`
+      ALTER TABLE "share_links"
+      ALTER COLUMN "token" TYPE varchar(32)
+    `);
+  }
+}

--- a/backend/src/share/share.service.ts
+++ b/backend/src/share/share.service.ts
@@ -132,7 +132,7 @@ export class ShareService {
     if (!link) throw new NotFoundException('分享不存在或已被取消');
 
     // 状态校验：过期/次数耗尽/取消
-    this.assertShareUsable(link);
+    await this.assertShareUsable(link);
 
     // 严格模式：需要密码但未通过 → 不查询 target
     if (link.password && !accessJwt) {
@@ -230,7 +230,7 @@ export class ShareService {
     const link = await this.shareLinkRepo.findOne({ where: { token, isDeleted: false } });
     if (!link) throw new NotFoundException('分享不存在');
 
-    this.assertShareUsable(link);
+    await this.assertShareUsable(link);
 
     // 严格模式：密码校验
     if (link.password) {
@@ -274,10 +274,17 @@ export class ShareService {
       skip: (page - 1) * limit,
       take: limit,
     });
-    return { items, total, page, limit };
+    // 不暴露 bcrypt 密码哈希，只返回 hasPassword 布尔值
+    return { items: items.map((s) => this.sanitizeShareLink(s)), total, page, limit };
   }
 
-  async getShareById(id: string, creatorId: string): Promise<ShareLink> {
+  async getShareById(id: string, creatorId: string) {
+    const link = await this.getShareByIdRaw(id, creatorId);
+    return this.sanitizeShareLink(link);
+  }
+
+  /** 内部方法：返回原始 ShareLink 实体（含 password），供 update/cancel 使用 */
+  private async getShareByIdRaw(id: string, creatorId: string): Promise<ShareLink> {
     const link = await this.shareLinkRepo.findOne({
       where: { id, creatorId, isDeleted: false },
     });
@@ -285,8 +292,14 @@ export class ShareService {
     return link;
   }
 
-  async updateShare(id: string, creatorId: string, dto: UpdateShareDto): Promise<ShareLink> {
-    const link = await this.getShareById(id, creatorId);
+  /** 去除 password 字段，替换为 hasPassword 布尔值 */
+  private sanitizeShareLink(link: ShareLink) {
+    const { password, ...rest } = link;
+    return { ...rest, hasPassword: !!password };
+  }
+
+  async updateShare(id: string, creatorId: string, dto: UpdateShareDto) {
+    const link = await this.getShareByIdRaw(id, creatorId);
     if (dto.password !== undefined) {
       link.password = dto.password ? await bcrypt.hash(dto.password, 10) : null;
     }
@@ -308,7 +321,7 @@ export class ShareService {
   }
 
   async cancelShare(id: string, creatorId: string): Promise<void> {
-    const link = await this.getShareById(id, creatorId);
+    const link = await this.getShareByIdRaw(id, creatorId);
     link.isDeleted = true;
     link.status = ShareLinkStatus.DISABLED;
     await this.shareLinkRepo.save(link);


### PR DESCRIPTION
- /files/public/:id 端点改为懒创建 ShareLink 并重定向至 /s/:id
- 修复还原文件夹时误恢复独立删除的子项
- 扩展 token 字段长度至 64 以兼容 UUID
- 移除 API 响应中的密码哈希，改为 hasPassword 布尔值
- 修正 assertShareUsable 为异步调用